### PR TITLE
feat: add parallel steps via `step.parallel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,28 @@ step
   .if(isBranch("main"));
 ```
 
+A few things to know:
+
+- Every step in a parallel block runs concurrently. There is no ordering
+  _within_ a block — for an ordered sequence, use a single step with a
+  multi-command `run`, or sequence the work across separate steps outside the
+  block.
+- GitHub runs at most 10 steps in a block concurrently; additional steps are
+  queued until a slot frees up.
+- Because members are unordered, a member cannot be ordered relative to another
+  member, and a member must be a single step (not a nested group). Each of these
+  throws a clear error:
+
+  ```
+  Error: Steps in a parallel group cannot depend on each other: A → B
+  Error: Steps in a parallel group cannot be ordered after each other: A → B
+  Error: Parallel groups cannot be nested.
+  Error: A parallel group member cannot itself be a group of steps — each member must be a single step.
+  ```
+
+- If a member is dropped by its `if` condition, the block collapses to the
+  remaining steps (and to a plain step if only one remains).
+
 ## Typed matrix
 
 `defineMatrix()` gives you typed access to matrix values:

--- a/README.md
+++ b/README.md
@@ -433,6 +433,45 @@ library throws with the cycle path:
 Error: Cycle detected in step ordering: A → B → A
 ```
 
+## Parallel steps
+
+`step.parallel()` groups steps into a
+[GitHub Actions `parallel:` block](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/)
+so they run concurrently within a single job:
+
+```ts
+const a = step({ name: "A", run: "echo a" });
+const b = step({ name: "B", run: "echo b" });
+
+workflow({
+  ...,
+  jobs: [{
+    id: "ci",
+    runsOn: "ubuntu-latest",
+    steps: [step.parallel(a, b)],
+  }],
+});
+```
+
+```yaml
+steps:
+  - parallel:
+      - name: A
+        run: echo a
+      - name: B
+        run: echo b
+```
+
+The prefix-builder form works too, so deps and conditions apply to the whole
+group (and propagate to its members and their dependencies):
+
+```ts
+step
+  .dependsOn(checkout)
+  .parallel(clippy, fmt)
+  .if(isBranch("main"));
+```
+
 ## Typed matrix
 
 `defineMatrix()` gives you typed access to matrix values:

--- a/README.md
+++ b/README.md
@@ -462,38 +462,6 @@ steps:
         run: echo b
 ```
 
-The prefix-builder form works too, so deps and conditions apply to the whole
-group (and propagate to its members and their dependencies):
-
-```ts
-step
-  .dependsOn(checkout)
-  .parallel(clippy, fmt)
-  .if(isBranch("main"));
-```
-
-A few things to know:
-
-- Every step in a parallel block runs concurrently. There is no ordering
-  _within_ a block — for an ordered sequence, use a single step with a
-  multi-command `run`, or sequence the work across separate steps outside the
-  block.
-- GitHub runs at most 10 steps in a block concurrently; additional steps are
-  queued until a slot frees up.
-- Because members are unordered, a member cannot be ordered relative to another
-  member, and a member must be a single step (not a nested group). Each of these
-  throws a clear error:
-
-  ```
-  Error: Steps in a parallel group cannot depend on each other: A → B
-  Error: Steps in a parallel group cannot be ordered after each other: A → B
-  Error: Parallel groups cannot be nested.
-  Error: A parallel group member cannot itself be a group of steps — each member must be a single step.
-  ```
-
-- If a member is dropped by its `if` condition, the block collapses to the
-  remaining steps (and to a plain step if only one remains).
-
 ## Typed matrix
 
 `defineMatrix()` gives you typed access to matrix values:

--- a/src/job.ts
+++ b/src/job.ts
@@ -158,24 +158,31 @@ function combineAndConditions(
 }
 
 /**
- * Returns a step's config.if as a ConditionLike suitable for passing down
- * to dependencies, or undefined if it references step outputs (which would
- * create circular condition dependencies).
+ * Returns a condition suitable for passing down to dependencies, or undefined
+ * if it references step outputs (which would create circular condition
+ * dependencies — a dependency cannot be gated on an output produced by a step
+ * that runs after it).
  */
+function propagatableCondition(
+  condition: ConditionLike | undefined,
+): ConditionLike | undefined {
+  if (condition == null) return undefined;
+  if (condition instanceof Condition) {
+    for (const source of condition.sources) {
+      if (source instanceof Step) return undefined;
+    }
+  }
+  if (condition instanceof ExpressionValue) {
+    for (const source of condition.allSources) {
+      if (source instanceof Step) return undefined;
+    }
+  }
+  return condition;
+}
+
+/** Returns a step's config.if if it is safe to propagate to dependencies. */
 function propagatableConfigIf(step: Step<string>): ConditionLike | undefined {
-  const configIf = step.config.if;
-  if (configIf == null) return undefined;
-  if (configIf instanceof Condition) {
-    for (const source of configIf.sources) {
-      if (source instanceof Step) return undefined;
-    }
-  }
-  if (configIf instanceof ExpressionValue) {
-    for (const source of configIf.allSources) {
-      if (source instanceof Step) return undefined;
-    }
-  }
-  return configIf;
+  return propagatableCondition(step.config.if);
 }
 
 interface DeferredAfterDep {
@@ -273,10 +280,12 @@ function flattenStepLike(
           ),
         );
       }
-      // compute aggregate dep context: newContext AND (OR of children's
+      // compute aggregate dep context: context AND (OR of children's
       // config.ifs). If any child is unconditional, or the OR is a tautology,
-      // just use newContext.
-      let compositeDepsCtx: ConditionLike | undefined = newContext;
+      // just use the context. The context is filtered so an output-referencing
+      // condition doesn't propagate to dependencies (circular dependency).
+      const depBaseCtx = propagatableCondition(newContext);
+      let compositeDepsCtx: ConditionLike | undefined = depBaseCtx;
       if (item.dependencies.length > 0) {
         const childIfs: ConditionLike[] = [];
         let allConditional = true;
@@ -293,7 +302,7 @@ function flattenStepLike(
             childIfs.map((c) => toCondition(c)),
           );
           if (orCond != null) {
-            compositeDepsCtx = combineAndConditions(newContext, orCond);
+            compositeDepsCtx = combineAndConditions(depBaseCtx, orCond);
           }
         }
       }
@@ -328,9 +337,11 @@ function flattenStepLike(
     if (isLeaf) leafSteps.push(step);
     if (parallelGroup) recordMember(membership, parallelGroup, step);
     applyContextCondition(entry, newContext);
-    // include step's config.if in the dep context
+    // include step's config.if in the dep context. both the context and the
+    // config.if are filtered so output-referencing conditions don't propagate
+    // to dependencies (which would create a circular condition dependency).
     const depContext = combineAndConditions(
-      newContext,
+      propagatableCondition(newContext),
       propagatableConfigIf(step),
     );
     for (const dep of item.dependencies) {

--- a/src/job.ts
+++ b/src/job.ts
@@ -211,6 +211,21 @@ function recordMember(
 }
 
 /**
+ * Rejects a composite step used directly as a parallel group member. Members
+ * run concurrently with no ordering, so a member cannot itself be a nested
+ * parallel group or a sequential group of steps.
+ */
+function throwInvalidParallelMember(composite: Step<string>): never {
+  if (composite.kind === "parallel") {
+    throw new Error("Parallel groups cannot be nested.");
+  }
+  throw new Error(
+    "A parallel group member cannot itself be a group of steps — " +
+      "each member must be a single step.",
+  );
+}
+
+/**
  * Recursively flattens a StepLike tree into a flat graph of Steps with
  * per-job dependencies and conditions. Returns the leaf-level Steps that
  * were contributed, so parent composite steps can apply their modifiers.
@@ -241,6 +256,7 @@ function flattenStepLike(
     if (step.children.length > 0) {
       // StepRef wrapping composite step: recurse with combined context.
       // a parallel composite makes its children concurrent members.
+      if (parallelGroup != null) throwInvalidParallelMember(step);
       const childGroup = step.kind === "parallel" ? step : parallelGroup;
       const contributed: Step<string>[] = [];
       for (const child of step.children) {
@@ -337,6 +353,7 @@ function flattenStepLike(
   if (item.children.length > 0) {
     // composite step: recurse into children with same context.
     // a parallel composite makes its children concurrent members.
+    if (parallelGroup != null) throwInvalidParallelMember(item);
     const childGroup = item.kind === "parallel" ? item : parallelGroup;
     const contributed: Step<string>[] = [];
     for (const child of item.children) {
@@ -562,7 +579,17 @@ export class Job implements ExpressionSource {
       }
       for (const dep of entry.afterDeps) {
         const to = repOf(dep);
-        if (to !== from) cEntry.afterDeps.add(to);
+        if (to === from) {
+          if (s !== dep) {
+            throw new Error(
+              `Steps in a parallel group cannot be ordered after each other: ${
+                stepLabel(dep)
+              } → ${stepLabel(s)}`,
+            );
+          }
+          continue;
+        }
+        cEntry.afterDeps.add(to);
       }
     }
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -92,6 +92,15 @@ interface GraphEntry {
   hasUnconditionalContext?: boolean;
 }
 
+/**
+ * An ordered unit of resolved steps: either a single step (`parallel: false`)
+ * or a parallel group whose `steps` run concurrently (`parallel: true`).
+ */
+interface ResolvedUnit {
+  parallel: boolean;
+  steps: Step<string>[];
+}
+
 function ensureEntry(
   graph: Map<Step<string>, GraphEntry>,
   step: Step<string>,
@@ -175,6 +184,33 @@ interface DeferredAfterDep {
 }
 
 /**
+ * Tracks which leaf steps are direct concurrent members of a parallel group.
+ * A step pulled in only as a dependency is NOT a member — it is hoisted to run
+ * before the group.
+ */
+interface Membership {
+  /** member step → the parallel group composite it belongs to */
+  memberToGroup: Map<Step<string>, Step<string>>;
+  /** parallel group → its member steps, in declaration order */
+  groupMembers: Map<Step<string>, Step<string>[]>;
+}
+
+function recordMember(
+  membership: Membership,
+  group: Step<string>,
+  step: Step<string>,
+): void {
+  if (membership.memberToGroup.has(step)) return;
+  membership.memberToGroup.set(step, group);
+  let members = membership.groupMembers.get(group);
+  if (!members) {
+    members = [];
+    membership.groupMembers.set(group, members);
+  }
+  members.push(step);
+}
+
+/**
  * Recursively flattens a StepLike tree into a flat graph of Steps with
  * per-job dependencies and conditions. Returns the leaf-level Steps that
  * were contributed, so parent composite steps can apply their modifiers.
@@ -192,7 +228,9 @@ function flattenStepLike(
   isLeaf: boolean,
   leafSteps: Step<string>[],
   deferredAfterDeps: DeferredAfterDep[],
+  membership: Membership,
   contextCondition?: ConditionLike,
+  parallelGroup?: Step<string>,
 ): Step<string>[] {
   const item = normalizeStepLike(rawItem);
   if (item instanceof StepRef) {
@@ -201,7 +239,9 @@ function flattenStepLike(
     const newContext = combineAndConditions(contextCondition, item.condition);
 
     if (step.children.length > 0) {
-      // StepRef wrapping composite step: recurse with combined context
+      // StepRef wrapping composite step: recurse with combined context.
+      // a parallel composite makes its children concurrent members.
+      const childGroup = step.kind === "parallel" ? step : parallelGroup;
       const contributed: Step<string>[] = [];
       for (const child of step.children) {
         contributed.push(
@@ -211,7 +251,9 @@ function flattenStepLike(
             isLeaf,
             leafSteps,
             deferredAfterDeps,
+            membership,
             newContext,
+            childGroup,
           ),
         );
       }
@@ -240,7 +282,8 @@ function flattenStepLike(
         }
       }
 
-      // apply deps once with aggregate context, add to all children's dep sets
+      // apply deps once with aggregate context, add to all children's dep sets.
+      // deps are not group members — they are hoisted to run before the group.
       for (const dep of item.dependencies) {
         const depSteps = flattenStepLike(
           dep,
@@ -248,6 +291,7 @@ function flattenStepLike(
           false,
           [],
           deferredAfterDeps,
+          membership,
           compositeDepsCtx,
         );
         for (const s of contributed) {
@@ -266,6 +310,7 @@ function flattenStepLike(
     // StepRef wrapping leaf step
     const entry = ensureEntry(graph, step);
     if (isLeaf) leafSteps.push(step);
+    if (parallelGroup) recordMember(membership, parallelGroup, step);
     applyContextCondition(entry, newContext);
     // include step's config.if in the dep context
     const depContext = combineAndConditions(
@@ -273,7 +318,14 @@ function flattenStepLike(
       propagatableConfigIf(step),
     );
     for (const dep of item.dependencies) {
-      flattenDep(dep, entry.deps, graph, deferredAfterDeps, depContext);
+      flattenDep(
+        dep,
+        entry.deps,
+        graph,
+        deferredAfterDeps,
+        membership,
+        depContext,
+      );
     }
     for (const dep of item.afterDependencies) {
       deferredAfterDeps.push({ step, target: dep });
@@ -283,7 +335,9 @@ function flattenStepLike(
 
   // Step (leaf or composite)
   if (item.children.length > 0) {
-    // composite step: recurse into children with same context
+    // composite step: recurse into children with same context.
+    // a parallel composite makes its children concurrent members.
+    const childGroup = item.kind === "parallel" ? item : parallelGroup;
     const contributed: Step<string>[] = [];
     for (const child of item.children) {
       contributed.push(
@@ -293,7 +347,9 @@ function flattenStepLike(
           isLeaf,
           leafSteps,
           deferredAfterDeps,
+          membership,
           contextCondition,
+          childGroup,
         ),
       );
     }
@@ -303,6 +359,7 @@ function flattenStepLike(
   // leaf step
   const entry = ensureEntry(graph, item);
   if (isLeaf) leafSteps.push(item);
+  if (parallelGroup) recordMember(membership, parallelGroup, item);
   applyContextCondition(entry, contextCondition);
   return [item];
 }
@@ -313,6 +370,7 @@ function flattenDep(
   targetSet: Set<Step<string>>,
   graph: Map<Step<string>, GraphEntry>,
   deferredAfterDeps: DeferredAfterDep[],
+  membership: Membership,
   contextCondition?: ConditionLike,
 ): void {
   const steps = flattenStepLike(
@@ -321,6 +379,7 @@ function flattenDep(
     false,
     [],
     deferredAfterDeps,
+    membership,
     contextCondition,
   );
   for (const s of steps) {
@@ -368,6 +427,7 @@ export class Job implements ExpressionSource {
   // cached graph — built lazily
   #cachedGraph?: Map<Step<string>, GraphEntry>;
   #cachedLeafSteps?: Step<string>[];
+  #cachedMembership?: Membership;
 
   constructor(
     id: string,
@@ -405,17 +465,33 @@ export class Job implements ExpressionSource {
   #buildGraph(): {
     graph: Map<Step<string>, GraphEntry>;
     leafSteps: Step<string>[];
+    membership: Membership;
   } {
-    if (this.#cachedGraph && this.#cachedLeafSteps) {
-      return { graph: this.#cachedGraph, leafSteps: this.#cachedLeafSteps };
+    if (this.#cachedGraph && this.#cachedLeafSteps && this.#cachedMembership) {
+      return {
+        graph: this.#cachedGraph,
+        leafSteps: this.#cachedLeafSteps,
+        membership: this.#cachedMembership,
+      };
     }
 
     const graph = new Map<Step<string>, GraphEntry>();
     const leafSteps: Step<string>[] = [];
     const deferredAfterDeps: DeferredAfterDep[] = [];
+    const membership: Membership = {
+      memberToGroup: new Map(),
+      groupMembers: new Map(),
+    };
 
     for (const item of this.#leafItems) {
-      flattenStepLike(item, graph, true, leafSteps, deferredAfterDeps);
+      flattenStepLike(
+        item,
+        graph,
+        true,
+        leafSteps,
+        deferredAfterDeps,
+        membership,
+      );
     }
 
     addConditionSourceDeps(graph);
@@ -431,34 +507,81 @@ export class Job implements ExpressionSource {
 
     this.#cachedGraph = graph;
     this.#cachedLeafSteps = leafSteps;
-    return { graph, leafSteps };
+    this.#cachedMembership = membership;
+    return { graph, leafSteps, membership };
   }
 
   resolveSteps(): Step<string>[] {
     const { graph, leafSteps } = this.#buildGraph();
-    const allSteps = new Set(graph.keys());
+    const priority = computePriorities(graph, leafSteps);
+    return topoSort(new Set(graph.keys()), priority, graph);
+  }
 
-    // compute priority: each step gets the minimum leaf index of any
-    // leaf step that transitively depends on it (directly or via
-    // condition sources). This makes the topo sort respect steps order.
-    const priority = new Map<Step<string>, number>();
-    const assignPriority = (s: Step<string>, p: number) => {
-      const current = priority.get(s);
-      if (current !== undefined && current <= p) return;
-      priority.set(s, p);
-      const entry = graph.get(s);
-      if (!entry) return;
+  /**
+   * Resolves the job's steps into ordered units. Each unit is either a single
+   * step or a parallel group whose members run concurrently. Parallel groups
+   * are contracted to a single node for ordering, so the whole block is placed
+   * as a unit relative to its dependencies and stays contiguous in the output.
+   */
+  #resolveUnits(): ResolvedUnit[] {
+    const { graph, leafSteps, membership } = this.#buildGraph();
+    const { memberToGroup, groupMembers } = membership;
+    const priority = computePriorities(graph, leafSteps);
+
+    // representative node of a step: its parallel group, or the step itself
+    const repOf = (s: Step<string>): Step<string> => memberToGroup.get(s) ?? s;
+
+    // build a contracted graph with one node per group + each free step
+    const nodes = new Set<Step<string>>();
+    for (const s of graph.keys()) nodes.add(repOf(s));
+
+    const contracted = new Map<Step<string>, GraphEntry>();
+    for (const node of nodes) {
+      contracted.set(node, {
+        deps: new Set(),
+        afterDeps: new Set(),
+        contexts: [],
+      });
+    }
+    for (const [s, entry] of graph) {
+      const from = repOf(s);
+      const cEntry = contracted.get(from)!;
       for (const dep of entry.deps) {
-        if (allSteps.has(dep)) {
-          assignPriority(dep, p);
+        const to = repOf(dep);
+        if (to === from) {
+          if (s !== dep) {
+            throw new Error(
+              `Steps in a parallel group cannot depend on each other: ${
+                stepLabel(dep)
+              } → ${stepLabel(s)}`,
+            );
+          }
+          continue;
         }
+        cEntry.deps.add(to);
       }
-    };
-    for (let i = 0; i < leafSteps.length; i++) {
-      assignPriority(leafSteps[i], i);
+      for (const dep of entry.afterDeps) {
+        const to = repOf(dep);
+        if (to !== from) cEntry.afterDeps.add(to);
+      }
     }
 
-    return topoSort(allSteps, priority, graph);
+    // contracted priority = best (minimum) priority among the node's members
+    const contractedPriority = new Map<Step<string>, number>();
+    for (const [s, p] of priority) {
+      const node = repOf(s);
+      const current = contractedPriority.get(node);
+      if (current === undefined || p < current) {
+        contractedPriority.set(node, p);
+      }
+    }
+
+    return topoSort(nodes, contractedPriority, contracted).map((node) => {
+      const members = groupMembers.get(node);
+      return members
+        ? { parallel: true, steps: members }
+        : { parallel: false, steps: [node] };
+    });
   }
 
   inferNeeds(stepOwners?: Map<Step<string>, Job[]>): Job[] {
@@ -659,17 +782,30 @@ export class Job implements ExpressionSource {
 
     // steps
     const { graph } = this.#buildGraph();
-    const resolvedSteps = this.resolveSteps();
+    const units = this.#resolveUnits();
     const effectiveConditions = computeEffectiveConditions(
-      resolvedSteps,
+      units.flatMap((u) => u.steps),
       graph,
     );
-    result.steps = resolvedSteps
-      .filter((s) => {
-        const cond = effectiveConditions.get(s);
-        return cond == null || !isAlwaysFalse(cond);
-      })
-      .map((s) => s.toYaml(effectiveConditions.get(s)));
+    const isVisible = (s: Step<string>) => {
+      const cond = effectiveConditions.get(s);
+      return cond == null || !isAlwaysFalse(cond);
+    };
+    const serialize = (s: Step<string>) => s.toYaml(effectiveConditions.get(s));
+
+    const steps: unknown[] = [];
+    for (const unit of units) {
+      const visible = unit.steps.filter(isVisible);
+      if (visible.length === 0) continue;
+      // a parallel block only makes sense with more than one step; collapse a
+      // single remaining step back to a normal sequential step
+      if (unit.parallel && visible.length > 1) {
+        steps.push({ parallel: visible.map(serialize) });
+      } else {
+        for (const s of visible) steps.push(serialize(s));
+      }
+    }
+    result.steps = steps;
 
     return result;
   }
@@ -979,6 +1115,35 @@ function extractCommonFactors(terms: Condition[]): Condition | undefined {
 }
 
 // --- topological sort ---
+
+/**
+ * Computes step priorities: each step gets the minimum leaf index of any leaf
+ * step that transitively depends on it (directly or via condition sources).
+ * This makes the topological sort respect the declared `steps` order.
+ */
+function computePriorities(
+  graph: Map<Step<string>, GraphEntry>,
+  leafSteps: Step<string>[],
+): Map<Step<string>, number> {
+  const allSteps = new Set(graph.keys());
+  const priority = new Map<Step<string>, number>();
+  const assignPriority = (s: Step<string>, p: number) => {
+    const current = priority.get(s);
+    if (current !== undefined && current <= p) return;
+    priority.set(s, p);
+    const entry = graph.get(s);
+    if (!entry) return;
+    for (const dep of entry.deps) {
+      if (allSteps.has(dep)) {
+        assignPriority(dep, p);
+      }
+    }
+  };
+  for (let i = 0; i < leafSteps.length; i++) {
+    assignPriority(leafSteps[i], i);
+  }
+  return priority;
+}
 
 function topoSort(
   steps: Set<Step<string>>,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,5 +1,6 @@
 export { Step, step, StepRef } from "./step.ts";
 export type {
+  CompositeKind,
   ConditionLike,
   ConfigValue,
   StepBuilder,

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -1044,6 +1044,51 @@ jobs:
   );
 });
 
+Deno.test("depending on a group and gating on a member's output via .if() works", () => {
+  setup();
+  const gen = step({
+    id: "gen",
+    name: "Gen",
+    run: "echo x=1 >> $GITHUB_OUTPUT",
+    outputs: ["x"],
+  });
+  const b = step({ name: "B", run: "echo b" });
+  const group = step.parallel(gen, b);
+  // builder .if() referencing a member's output — must not cycle
+  const done = step.dependsOn(group).if(gen.outputs.x.equals("1"))({
+    name: "Done",
+    run: "echo done",
+  });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [done] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - name: Gen
+            id: gen
+            run: echo x=1 >> $GITHUB_OUTPUT
+          - name: B
+            run: echo b
+      - name: Done
+        if: steps.gen.outputs.x == '1'
+        run: echo done
+`,
+  );
+});
+
 Deno.test("a cross-job artifact download as a parallel member still infers needs", () => {
   setup();
   const buildOutput = artifact("build-output");
@@ -1718,6 +1763,47 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Build
+        id: build
+        run: echo 'status=ok' >> $GITHUB_OUTPUT
+      - name: Test
+        if: steps.build.outputs.status == 'ok'
+        run: cargo test
+`,
+  );
+});
+
+Deno.test("a builder .if() referencing a dependency's output does not cycle", () => {
+  setup();
+  const build = step({
+    id: "build",
+    name: "Build",
+    run: "echo 'status=ok' >> $GITHUB_OUTPUT",
+    outputs: ["status"],
+  });
+  // the condition is set via the builder .if() (not config.if) and references
+  // build's own output. it must not propagate onto build as a self-dependency.
+  const test = step.dependsOn(build).if(build.outputs.status.equals("ok"))({
+    name: "Test",
+    run: "cargo test",
+  });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [test] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
       - name: Build
         id: build
         run: echo 'status=ok' >> $GITHUB_OUTPUT

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -317,6 +317,169 @@ jobs:
   );
 });
 
+// --- parallel steps ---
+
+Deno.test("step.parallel emits a parallel block", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+  const b = step({ name: "B", run: "echo b" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [step.parallel(a, b)] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - name: A
+            run: echo a
+          - name: B
+            run: echo b
+`,
+  );
+});
+
+Deno.test("parallel members' shared dep is hoisted before the block", () => {
+  setup();
+  const checkout = step({ name: "Checkout" });
+  const clippy = step.dependsOn(checkout)({
+    name: "Clippy",
+    run: "cargo clippy",
+  });
+  const fmt = step.dependsOn(checkout)({
+    name: "Fmt",
+    run: "cargo fmt --check",
+  });
+  const lint = step.parallel(clippy, fmt);
+  const done = step.dependsOn(lint)({ name: "Done", run: "echo done" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [done] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+      - parallel:
+          - name: Clippy
+            run: cargo clippy
+          - name: Fmt
+            run: cargo fmt --check
+      - name: Done
+        run: echo done
+`,
+  );
+});
+
+Deno.test("step.dependsOn(...).parallel(...).if(...) propagates to members and deps", () => {
+  setup();
+  const checkout = step({ name: "Checkout" });
+  const a = step({ name: "A", run: "echo a" });
+  const b = step({ name: "B", run: "echo b" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          step.dependsOn(checkout).parallel(a, b).if(isBranch("main")),
+        ],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: github.ref == 'refs/heads/main'
+      - parallel:
+          - name: A
+            if: github.ref == 'refs/heads/main'
+            run: echo a
+          - name: B
+            if: github.ref == 'refs/heads/main'
+            run: echo b
+`,
+  );
+});
+
+Deno.test("a parallel member filtered out by its condition collapses the block", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+  // always-false condition removes B, leaving a single concurrent step
+  const b = step({ name: "B", run: "echo b", if: conditions.isFalse() });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [step.parallel(a, b)] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: A
+        run: echo a
+`,
+  );
+});
+
+Deno.test("steps in a parallel group cannot depend on each other", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+  const b = step.dependsOn(a)({ name: "B", run: "echo b" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [step.parallel(a, b)] },
+    ],
+  });
+
+  assertThrows(
+    () => wf.toYamlString(),
+    Error,
+    "Steps in a parallel group cannot depend on each other",
+  );
+});
+
 // --- step with if condition ---
 
 Deno.test("step with if condition appears in YAML", () => {

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -476,7 +476,114 @@ Deno.test("steps in a parallel group cannot depend on each other", () => {
   assertThrows(
     () => wf.toYamlString(),
     Error,
-    "Steps in a parallel group cannot depend on each other",
+    "Steps in a parallel group cannot depend on each other: A → B",
+  );
+});
+
+Deno.test("steps in a parallel group cannot be ordered after each other", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+  const b = step.comesAfter(a)({ name: "B", run: "echo b" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [step.parallel(a, b)] },
+    ],
+  });
+
+  assertThrows(
+    () => wf.toYamlString(),
+    Error,
+    "Steps in a parallel group cannot be ordered after each other: A → B",
+  );
+});
+
+Deno.test("parallel groups cannot be nested", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+  const b = step({ name: "B", run: "echo b" });
+  const c = step({ name: "C", run: "echo c" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [step.parallel(a, step.parallel(b, c))],
+      },
+    ],
+  });
+
+  assertThrows(
+    () => wf.toYamlString(),
+    Error,
+    "Parallel groups cannot be nested.",
+  );
+});
+
+Deno.test("a parallel group member cannot be a sequential group of steps", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+  const b = step({ name: "B", run: "echo b" });
+  const c = step({ name: "C", run: "echo c" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [step.parallel(a, step(b, c))],
+      },
+    ],
+  });
+
+  assertThrows(
+    () => wf.toYamlString(),
+    Error,
+    "A parallel group member cannot itself be a group of steps",
+  );
+});
+
+Deno.test("a parallel group nested inside a sequential composite is allowed", () => {
+  setup();
+  const setup_ = step({ name: "Setup", run: "echo setup" });
+  const a = step({ name: "A", run: "echo a" });
+  const b = step({ name: "B", run: "echo b" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [step(setup_, step.parallel(a, b))],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        run: echo setup
+      - parallel:
+          - name: A
+            run: echo a
+          - name: B
+            run: echo b
+`,
   );
 });
 
@@ -5657,6 +5764,37 @@ Deno.test("unpinParsedYaml handles reusable workflow uses", () => {
     (obj.jobs.deploy as Record<string, unknown>).uses,
     "org/repo/.github/workflows/deploy.yml@main",
   );
+});
+
+Deno.test("unpinParsedYaml restores uses nested inside a parallel block", () => {
+  const hashA = "a".repeat(40);
+  const hashB = "b".repeat(40);
+  const obj = {
+    jobs: {
+      build: {
+        "runs-on": "ubuntu-latest",
+        steps: [
+          {
+            parallel: [
+              { uses: `actions/checkout@${hashA}` },
+              { uses: `actions/setup-node@${hashB}` },
+            ],
+          },
+          { run: "npm test" },
+        ],
+      },
+    },
+  };
+  const pins: PinEntry[] = [
+    { original: "actions/checkout@v6", hash: hashA },
+    { original: "actions/setup-node@v4", hash: hashB },
+  ];
+  unpinParsedYaml(obj, pins);
+  const block = obj.jobs.build.steps[0] as {
+    parallel: Record<string, unknown>[];
+  };
+  assertEquals(block.parallel[0].uses, "actions/checkout@v6");
+  assertEquals(block.parallel[1].uses, "actions/setup-node@v4");
 });
 
 Deno.test("runsOn supports string array", () => {

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -587,6 +587,561 @@ jobs:
   );
 });
 
+// --- parallel steps: coverage ---
+
+Deno.test("step.parallel() with no args throws", () => {
+  assertThrows(
+    () => step.parallel(),
+    Error,
+    "step.parallel() requires at least one argument",
+  );
+});
+
+Deno.test("step.parallel with a single member collapses to a plain step", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [step.parallel(a)] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: A
+        run: echo a
+`,
+  );
+});
+
+Deno.test("Step.kind reflects sequential vs parallel composites", () => {
+  setup();
+  const a = step({ name: "A" });
+  const b = step({ name: "B" });
+  assertEquals(step.parallel(a, b).kind, "parallel");
+  assertEquals(step(a, b).kind, "sequential");
+  assertEquals(a.kind, "sequential");
+});
+
+Deno.test("step.parallel accepts config objects and mixed arg forms", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        // plain config object, Step, and StepRef in one call
+        steps: [
+          step.parallel(
+            { name: "Cfg", run: "echo cfg" },
+            a,
+            step.if(isBranch("main"))({ name: "Ref", run: "echo ref" }),
+          ),
+        ],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - name: Cfg
+            run: echo cfg
+          - name: A
+            run: echo a
+          - name: Ref
+            if: github.ref == 'refs/heads/main'
+            run: echo ref
+`,
+  );
+});
+
+Deno.test("step.if(...).parallel(...) propagates the condition to members", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+  const b = step({ name: "B", run: "echo b" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [step.if(isBranch("main")).parallel(a, b)],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - name: A
+            if: github.ref == 'refs/heads/main'
+            run: echo a
+          - name: B
+            if: github.ref == 'refs/heads/main'
+            run: echo b
+`,
+  );
+});
+
+Deno.test("step.comesAfter(...).parallel(...) orders the block after the target", () => {
+  setup();
+  const x = step({ name: "X", run: "echo x" });
+  const a = step({ name: "A", run: "echo a" });
+  const b = step({ name: "B", run: "echo b" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [x, step.comesAfter(x).parallel(a, b)],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: X
+        run: echo x
+      - parallel:
+          - name: A
+            run: echo a
+          - name: B
+            run: echo b
+`,
+  );
+});
+
+Deno.test(".if() on a step.parallel(...) result propagates to members", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+  const b = step({ name: "B", run: "echo b" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [step.parallel(a, b).if(isBranch("main"))],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - name: A
+            if: github.ref == 'refs/heads/main'
+            run: echo a
+          - name: B
+            if: github.ref == 'refs/heads/main'
+            run: echo b
+`,
+  );
+});
+
+Deno.test("members with different conditions OR onto a shared dep (member deps)", () => {
+  setup();
+  const checkout = step({ name: "Checkout" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          step.parallel(
+            step.dependsOn(checkout).if(isBranch("main"))({
+              name: "A",
+              run: "echo a",
+            }),
+            step.dependsOn(checkout).if(isTag())({ name: "B", run: "echo b" }),
+          ),
+        ],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: 'github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')'
+      - parallel:
+          - name: A
+            if: github.ref == 'refs/heads/main'
+            run: echo a
+          - name: B
+            if: 'startsWith(github.ref, ''refs/tags/'')'
+            run: echo b
+`,
+  );
+});
+
+Deno.test("group-level dep gets OR of members' differing conditions", () => {
+  setup();
+  const checkout = step({ name: "Checkout" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          step.dependsOn(checkout).parallel(
+            step({ name: "A", run: "echo a", if: isBranch("main") }),
+            step({ name: "B", run: "echo b", if: isTag() }),
+          ),
+        ],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: 'github.ref == ''refs/heads/main'' || startsWith(github.ref, ''refs/tags/'')'
+      - parallel:
+          - name: A
+            if: github.ref == 'refs/heads/main'
+            run: echo a
+          - name: B
+            if: 'startsWith(github.ref, ''refs/tags/'')'
+            run: echo b
+`,
+  );
+});
+
+Deno.test("a parallel block whose members are all filtered out is omitted", () => {
+  setup();
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          step.parallel(
+            step({ name: "A", run: "echo a", if: conditions.isFalse() }),
+            step({ name: "B", run: "echo b", if: conditions.isFalse() }),
+          ),
+        ],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps: []
+`,
+  );
+});
+
+Deno.test("multiple parallel groups in one job emit separate blocks", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+  const b = step({ name: "B", run: "echo b" });
+  const c = step({ name: "C", run: "echo c" });
+  const d = step({ name: "D", run: "echo d" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [step.parallel(a, b), step.parallel(c, d)],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - name: A
+            run: echo a
+          - name: B
+            run: echo b
+      - parallel:
+          - name: C
+            run: echo c
+          - name: D
+            run: echo d
+`,
+  );
+});
+
+Deno.test("a member's full config serializes correctly inside the block", () => {
+  setup();
+  const b = step({ name: "B", run: "echo b" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          step.parallel(
+            step({
+              id: "m",
+              uses: "actions/foo@v1",
+              with: { x: 1 },
+              env: { E: "e" },
+              continueOnError: true,
+              timeoutMinutes: 5,
+              workingDirectory: "sub",
+              shell: "bash",
+              run: "echo hi",
+            }),
+            b,
+          ),
+        ],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - id: m
+            uses: actions/foo@v1
+            shell: bash
+            working-directory: sub
+            env:
+              E: e
+            continue-on-error: true
+            timeout-minutes: 5
+            with:
+              x: 1
+            run: echo hi
+          - name: B
+            run: echo b
+`,
+  );
+});
+
+Deno.test("a later step can gate on a parallel member's output", () => {
+  setup();
+  const gen = step({
+    id: "gen",
+    run: "echo x=1 >> $GITHUB_OUTPUT",
+    outputs: ["x"],
+  });
+  const b = step({ name: "B", run: "echo b" });
+  const group = step.parallel(gen, b);
+  const done = step.dependsOn(group)({
+    name: "Done",
+    run: "echo done",
+    if: gen.outputs.x.equals("1"),
+  });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [done] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - id: gen
+            run: echo x=1 >> $GITHUB_OUTPUT
+          - name: B
+            run: echo b
+      - name: Done
+        if: steps.gen.outputs.x == '1'
+        run: echo done
+`,
+  );
+});
+
+Deno.test("a cross-job artifact download as a parallel member still infers needs", () => {
+  setup();
+  const buildOutput = artifact("build-output");
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "build",
+        runsOn: "ubuntu-latest",
+        steps: [buildOutput.upload({ path: "dist/" })],
+      },
+      {
+        id: "deploy",
+        runsOn: "ubuntu-latest",
+        steps: [
+          step.parallel(
+            buildOutput.download({ dirPath: "dist/" }),
+            step({ name: "Other", run: "echo o" }),
+          ),
+        ],
+      },
+    ],
+  });
+
+  assertStringIncludes(
+    wf.toYamlString(),
+    "deploy:\n    needs:\n      - build",
+  );
+});
+
+Deno.test("the same parallel group reused across jobs emits in each", () => {
+  setup();
+  const a = step({ name: "A", run: "echo a" });
+  const b = step({ name: "B", run: "echo b" });
+  const shared = step.parallel(a, b);
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j1", runsOn: "ubuntu-latest", steps: [shared] },
+      { id: "j2", runsOn: "ubuntu-latest", steps: [shared] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j1:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - name: A
+            run: echo a
+          - name: B
+            run: echo b
+  j2:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - name: A
+            run: echo a
+          - name: B
+            run: echo b
+`,
+  );
+});
+
+Deno.test("pin/unpin round-trips a uses nested in a parallel block", () => {
+  setup();
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          step.parallel(
+            step({ uses: "actions/checkout@v6" }),
+            step({ uses: "actions/setup-node@v4" }),
+          ),
+        ],
+      },
+    ],
+  });
+
+  const original = wf.toYamlString();
+  const { content: pinned } = pinYamlContent(original, () => "a".repeat(40));
+  // mirrors the --lint comparison: unpin the stored file and compare to source
+  const unpinned = unpinParsedYaml(parse(pinned), parsePinComments(pinned));
+  assertEquals(JSON.stringify(unpinned), JSON.stringify(parse(original)));
+});
+
 // --- step with if condition ---
 
 Deno.test("step with if condition appears in YAML", () => {

--- a/src/pin.ts
+++ b/src/pin.ts
@@ -275,22 +275,34 @@ export function unpinParsedYaml(
         jobObj.uses = hashToOriginal.get(jobObj.uses);
       }
 
-      // steps
+      // steps (including steps nested inside parallel: blocks)
       if (Array.isArray(jobObj.steps)) {
         for (const s of jobObj.steps) {
-          if (typeof s === "object" && s !== null) {
-            const stepObj = s as Record<string, unknown>;
-            if (
-              typeof stepObj.uses === "string" &&
-              hashToOriginal.has(stepObj.uses)
-            ) {
-              stepObj.uses = hashToOriginal.get(stepObj.uses);
-            }
-          }
+          unpinStep(s, hashToOriginal);
         }
       }
     }
   }
 
   return obj;
+}
+
+/** Reverts a pinned hash on a single step, recursing into `parallel:` blocks. */
+function unpinStep(
+  step: unknown,
+  hashToOriginal: Map<string, string>,
+): void {
+  if (typeof step !== "object" || step === null) return;
+  const stepObj = step as Record<string, unknown>;
+  if (
+    typeof stepObj.uses === "string" &&
+    hashToOriginal.has(stepObj.uses)
+  ) {
+    stepObj.uses = hashToOriginal.get(stepObj.uses);
+  }
+  if (Array.isArray(stepObj.parallel)) {
+    for (const child of stepObj.parallel) {
+      unpinStep(child, hashToOriginal);
+    }
+  }
 }

--- a/src/step.ts
+++ b/src/step.ts
@@ -34,8 +34,16 @@ export function resetStepCounter(): void {
 
 export type StepLike = Step<string> | StepRef<string> | StepConfig;
 
+/**
+ * How a composite step's children relate to each other. "sequential" children
+ * run one after another (the default); "parallel" children run concurrently and
+ * serialize to a GitHub Actions `parallel:` block.
+ */
+export type CompositeKind = "sequential" | "parallel";
+
 export class Step<O extends string = never> implements ExpressionSource {
   readonly #id: string;
+  readonly #kind: CompositeKind;
   readonly config: StepConfig<O>;
   readonly outputs: { [K in O]: ExpressionValue };
   // cross-job step references for needs inference (e.g., artifact download → upload)
@@ -43,10 +51,10 @@ export class Step<O extends string = never> implements ExpressionSource {
   readonly children: readonly StepLike[];
 
   constructor(config: StepConfig<O>, crossJobDeps?: Step<string>[]);
-  constructor(children: readonly StepLike[]);
+  constructor(children: readonly StepLike[], kind?: CompositeKind);
   constructor(
     configOrChildren: StepConfig<O> | readonly StepLike[],
-    crossJobDeps?: Step<string>[],
+    second?: Step<string>[] | CompositeKind,
   ) {
     if (Array.isArray(configOrChildren)) {
       // composite step (group of children)
@@ -54,6 +62,7 @@ export class Step<O extends string = never> implements ExpressionSource {
         throw new Error("step() requires at least one step");
       }
       this.#id = `_step_${stepCounter++}`;
+      this.#kind = (second as CompositeKind | undefined) ?? "sequential";
       this.config = {} as StepConfig<O>;
       this._crossJobDeps = Object.freeze([]);
       this.outputs = {} as { [K in O]: ExpressionValue };
@@ -61,6 +70,8 @@ export class Step<O extends string = never> implements ExpressionSource {
       return;
     }
 
+    this.#kind = "sequential";
+    const crossJobDeps = second as Step<string>[] | undefined;
     const config = configOrChildren as StepConfig<O>;
     if (config.outputs?.length && !config.id) {
       throw new Error(
@@ -89,6 +100,11 @@ export class Step<O extends string = never> implements ExpressionSource {
 
   get id(): string {
     return this.#id;
+  }
+
+  /** Whether this composite's children run sequentially or in parallel. */
+  get kind(): CompositeKind {
+    return this.#kind;
   }
 
   dependsOn(...deps: StepLike[]): StepRef<O> {
@@ -167,6 +183,10 @@ export interface StepBuilder {
   if(condition: ConditionLike): StepBuilder;
   dependsOn(...deps: StepLike[]): StepBuilder;
   comesAfter(...deps: StepLike[]): StepBuilder;
+  /** Builds a parallel group from the args, carrying this builder's deps/condition. */
+  parallel(
+    ...args: (StepConfig | Step<string> | StepRef<string>)[]
+  ): StepRef<string>;
 }
 
 interface StepBuilderInit {
@@ -246,6 +266,14 @@ function createStepBuilder(init: StepBuilderInit): StepBuilder {
     });
   };
 
+  builder.parallel = (...args: unknown[]): StepRef<string> => {
+    return new StepRef(buildParallelFromArgs(...args), {
+      condition: init.condition,
+      dependencies: init.dependencies ?? [],
+      afterDependencies: init.afterDependencies ?? [],
+    });
+  };
+
   return builder;
 }
 
@@ -258,6 +286,14 @@ export interface StepFunction {
   if(condition: ConditionLike): StepBuilder;
   dependsOn(...deps: StepLike[]): StepBuilder;
   comesAfter(...deps: StepLike[]): StepBuilder;
+  /**
+   * Groups steps into a parallel block. The steps run concurrently and
+   * serialize to a GitHub Actions `parallel:` block. Shared dependencies
+   * (pulled in via `dependsOn`) are hoisted to run before the block.
+   */
+  parallel(
+    ...args: (StepConfig | Step<string> | StepRef<string>)[]
+  ): Step<string>;
 }
 
 export const step: StepFunction = Object.assign(
@@ -269,8 +305,23 @@ export const step: StepFunction = Object.assign(
       createStepBuilder({ dependencies: deps }),
     comesAfter: (...deps: StepLike[]): StepBuilder =>
       createStepBuilder({ afterDependencies: deps }),
+    parallel: (...args: unknown[]): Step<string> =>
+      buildParallelFromArgs(...args),
   },
 );
+
+/** Builds a parallel composite step from the given args. */
+function buildParallelFromArgs(...args: unknown[]): Step<string> {
+  if (args.length === 0) {
+    throw new Error("step.parallel() requires at least one argument");
+  }
+  const children: StepLike[] = args.map((item) =>
+    item instanceof Step || item instanceof StepRef
+      ? item
+      : new Step(item as StepConfig)
+  );
+  return new Step(children, "parallel");
+}
 
 // --- StepRef: immutable wrapper for per-usage deps/conditions ---
 


### PR DESCRIPTION
Adds `step.parallel(...)` (and `.parallel(...)` on the prefix builder) to group steps into a GitHub Actions `parallel:` block, running them concurrently within a job.

Resolution is now tree-aware: a parallel group is contracted to a single node for the topological sort, so the whole block is placed correctly relative to its dependencies and stays contiguous. Shared dependencies (pulled in via `dependsOn`) are hoisted to run before the block, and condition propagation flows through groups unchanged. Steps in the same group cannot depend on each other (throws a clear error).

Part of https://github.com/dsherret/gagen/issues/40