### PR TITLE
feat: background steps (background/wait/wait-all/cancel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,58 @@ steps:
         run: echo b
 ```
 
+## Background steps
+
+For finer control than `parallel` — long-running services, or non-blocking work
+that overlaps later steps — set `background: true` on a step and synchronize
+with `step.waitFor()`, `step.waitForAll()`, or `step.cancel()`.
+
+```ts
+const server = step({
+  id: "server",
+  name: "Start server",
+  run: "npm start",
+  background: true,
+});
+
+workflow({
+  ...,
+  jobs: [{
+    id: "e2e",
+    runsOn: "ubuntu-latest",
+    steps: [
+      server,
+      step({ name: "Run tests", run: "npm test" }),
+      step.waitFor(server),
+    ],
+  }],
+});
+```
+
+```yaml
+steps:
+  - name: Start server
+    id: server
+    run: npm start
+    background: true
+  - name: Run tests
+    run: npm test
+  - wait: server
+```
+
+- `step.waitFor(...steps)` → a `wait` step that blocks until the referenced
+  background steps finish (`wait: id`, or a list for several). It is ordered
+  after — and pulls in — the steps it waits on.
+- `step.waitForAll()` → a `wait-all` step that blocks until every active
+  background step finishes.
+- `step.cancel(step)` → a `cancel` step that terminates a background step.
+
+A background step must have an explicit `id` to be referenced by `waitFor` or
+`cancel`; otherwise the call throws. A maximum of 10 background steps run
+concurrently. Because ordering between background work and the steps that run
+alongside it is positional, list those steps in the order you want them (or use
+`comesAfter()`), the same as any other step.
+
 ## Typed matrix
 
 `defineMatrix()` gives you typed access to matrix values:

--- a/README.md
+++ b/README.md
@@ -468,6 +468,9 @@ For finer control than `parallel` — long-running services, or non-blocking wor
 that overlaps later steps — set `background: true` on a step and synchronize
 with `step.waitFor()`, `step.waitForAll()`, or `step.cancel()`.
 
+A long-running service is started in the background, used, then stopped with
+`step.cancel()` (it never exits on its own):
+
 ```ts
 const server = step({
   id: "server",
@@ -484,7 +487,7 @@ workflow({
     steps: [
       server,
       step({ name: "Run tests", run: "npm test" }),
-      step.waitFor(server),
+      step.cancel(server),
     ],
   }],
 });
@@ -498,7 +501,46 @@ steps:
     background: true
   - name: Run tests
     run: npm test
-  - wait: server
+  - cancel: server
+```
+
+`step.waitFor()` is instead for background work that finishes — kick it off, do
+something else while it runs, then block on it before the step that needs it:
+
+```ts
+const build = step({
+  id: "build",
+  name: "Build assets",
+  run: "npm run build",
+  background: true,
+});
+
+workflow({
+  ...,
+  jobs: [{
+    id: "ci",
+    runsOn: "ubuntu-latest",
+    steps: [
+      build,
+      step({ name: "Lint", run: "npm run lint" }), // runs while the build proceeds
+      step.waitFor(build),
+      step({ name: "Package", run: "npm run package" }),
+    ],
+  }],
+});
+```
+
+```yaml
+steps:
+  - name: Build assets
+    id: build
+    run: npm run build
+    background: true
+  - name: Lint
+    run: npm run lint
+  - wait: build
+  - name: Package
+    run: npm run package
 ```
 
 - `step.waitFor(...steps)` → a `wait` step that blocks until the referenced

--- a/README.md
+++ b/README.md
@@ -508,11 +508,12 @@ steps:
   background step finishes.
 - `step.cancel(step)` → a `cancel` step that terminates a background step.
 
-A background step must have an explicit `id` to be referenced by `waitFor` or
-`cancel`; otherwise the call throws. A maximum of 10 background steps run
-concurrently. Because ordering between background work and the steps that run
-alongside it is positional, list those steps in the order you want them (or use
-`comesAfter()`), the same as any other step.
+`waitFor`/`cancel` only target a background step with an explicit `id` (the id
+is needed to reference it in the generated YAML); otherwise the call throws. A
+maximum of 10 background steps run concurrently. Because ordering between
+background work and the steps that run alongside it is positional, list those
+steps in the order you want them (or use `comesAfter()`), the same as any other
+step.
 
 ## Typed matrix
 

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ that overlaps later steps — set `background: true` on a step and synchronize
 with `step.waitFor()`, `step.waitForAll()`, or `step.cancel()`.
 
 A long-running service is started in the background, used, then stopped with
-`step.cancel()` (it never exits on its own):
+`step.cancel()`:
 
 ```ts
 const server = step({
@@ -488,6 +488,7 @@ workflow({
       server,
       step({ name: "Run tests", run: "npm test" }),
       step.cancel(server),
+      // ...more steps go here...
     ],
   }],
 });

--- a/src/job.ts
+++ b/src/job.ts
@@ -207,6 +207,15 @@ function recordMember(
   group: Step<string>,
   step: Step<string>,
 ): void {
+  const c = step.config;
+  if (c.background || c.wait != null || c.waitAll || c.cancel != null) {
+    // a parallel block already runs each member as a background step with an
+    // implicit wait-all, so background/wait/wait-all/cancel members make no sense
+    throw new Error(
+      "A parallel group member cannot be a background, wait, wait-all, or " +
+        "cancel step.",
+    );
+  }
   if (membership.memberToGroup.has(step)) return;
   membership.memberToGroup.set(step, group);
   let members = membership.groupMembers.get(group);

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -1428,6 +1428,462 @@ Deno.test("a wait config referencing a step without an id throws at serializatio
   );
 });
 
+// --- background steps: review coverage ---
+
+Deno.test("step.waitFor pulls in the target's transitive deps", () => {
+  setup();
+  const setup_ = step({ name: "Setup", run: "setup" });
+  const server = step.dependsOn(setup_)({
+    id: "server",
+    run: "npm start",
+    background: true,
+  });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [step.waitFor(server)] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        run: setup
+      - id: server
+        run: npm start
+        background: true
+      - wait: server
+`,
+  );
+});
+
+Deno.test("step.waitFor deduplicates repeated targets", () => {
+  setup();
+  const a = step({ id: "a", run: "x", background: true });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [a, step.waitFor(a, a)] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: a
+        run: x
+        background: true
+      - wait: a
+`,
+  );
+});
+
+Deno.test("a wait step can carry a condition", () => {
+  setup();
+  const server = step({ id: "server", run: "npm start", background: true });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [server, step.waitFor(server).if(isBranch("main"))],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: npm start
+        background: true
+      - if: github.ref == 'refs/heads/main'
+        wait: server
+`,
+  );
+});
+
+Deno.test("a background step without an id serializes fine", () => {
+  setup();
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          step({ name: "Telemetry", run: "./telemetry.sh", background: true }),
+          step({ name: "Pack", run: "pack" }),
+        ],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Telemetry
+        run: ./telemetry.sh
+        background: true
+      - name: Pack
+        run: pack
+`,
+  );
+});
+
+Deno.test("background works on a uses step", () => {
+  setup();
+  const svc = step({
+    id: "svc",
+    uses: "actions/foo@v1",
+    with: { port: 8080 },
+    background: true,
+  });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [svc, step.waitFor(svc)] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: svc
+        uses: actions/foo@v1
+        with:
+          port: 8080
+        background: true
+      - wait: svc
+`,
+  );
+});
+
+Deno.test("config-form wait / waitAll / cancel serialize", () => {
+  setup();
+  const a = step({ id: "a", run: "a", background: true });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          a,
+          step({ name: "W", wait: a }),
+          step({ name: "WA", waitAll: true }),
+          step({ name: "C", cancel: a }),
+        ],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: a
+        run: a
+        background: true
+      - name: W
+        wait: a
+      - name: WA
+        wait-all: null
+      - name: C
+        cancel: a
+`,
+  );
+});
+
+Deno.test("a single-element wait list collapses to a scalar", () => {
+  setup();
+  const a = step({ id: "a", run: "a", background: true });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [a, step({ name: "W", wait: [a] })],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: a
+        run: a
+        background: true
+      - name: W
+        wait: a
+`,
+  );
+});
+
+Deno.test("modifiers apply to waitFor/cancel/waitForAll results", () => {
+  setup();
+  const mon = step({ id: "mon", run: "m", background: true });
+  const main = step({ name: "Main", run: "main" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          mon,
+          main,
+          step.cancel(mon).comesAfter(main),
+          step.waitForAll().if(isBranch("main")),
+        ],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: mon
+        run: m
+        background: true
+      - name: Main
+        run: main
+      - cancel: mon
+      - if: github.ref == 'refs/heads/main'
+        wait-all: null
+`,
+  );
+});
+
+Deno.test("a step can depend on a waitFor step", () => {
+  setup();
+  const server = step({ id: "server", run: "s", background: true });
+  const waited = step.waitFor(server);
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          server,
+          step.dependsOn(waited)({ name: "After", run: "after" }),
+        ],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: s
+        background: true
+      - wait: server
+      - name: After
+        run: after
+`,
+  );
+});
+
+Deno.test("a background step cannot be a parallel group member", () => {
+  setup();
+  const server = step({ id: "server", run: "s", background: true });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [step.parallel(server, step({ name: "X", run: "x" }))],
+      },
+    ],
+  });
+
+  assertThrows(
+    () => wf.toYamlString(),
+    Error,
+    "A parallel group member cannot be a background, wait, wait-all, or cancel step",
+  );
+});
+
+Deno.test("a wait step cannot be a parallel group member", () => {
+  setup();
+  const server = step({ id: "server", run: "s", background: true });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          step.parallel(step.waitFor(server), step({ name: "X", run: "x" })),
+        ],
+      },
+    ],
+  });
+
+  assertThrows(
+    () => wf.toYamlString(),
+    Error,
+    "A parallel group member cannot be a background, wait, wait-all, or cancel step",
+  );
+});
+
+Deno.test("a step cannot combine wait, wait-all, or cancel", () => {
+  setup();
+  const a = step({ id: "a", run: "a", background: true });
+  assertThrows(
+    () => step({ wait: a, cancel: a }),
+    Error,
+    "wait, wait-all, and cancel are mutually exclusive",
+  );
+});
+
+Deno.test("a wait/cancel step cannot also do work", () => {
+  setup();
+  const a = step({ id: "a", run: "a", background: true });
+  assertThrows(
+    () => step({ name: "Bad", run: "echo", wait: a }),
+    Error,
+    "A wait step cannot also have run",
+  );
+});
+
+Deno.test("step.waitFor requires the target to be a background step", () => {
+  setup();
+  const a = step({ id: "a", run: "x" });
+  assertThrows(
+    () => step.waitFor(a),
+    Error,
+    "step.waitFor() can only target a background step",
+  );
+});
+
+Deno.test("step.cancel requires the target to be a background step", () => {
+  setup();
+  const a = step({ id: "a", run: "x" });
+  assertThrows(
+    () => step.cancel(a),
+    Error,
+    "step.cancel() can only target a background step",
+  );
+});
+
+Deno.test("a cancel config referencing a step without an id throws", () => {
+  setup();
+  const noId = step({ name: "No id", run: "x", background: true });
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [noId, step({ name: "C", cancel: noId })],
+      },
+    ],
+  });
+
+  assertThrows(
+    () => wf.toYamlString(),
+    Error,
+    "a step referenced by `wait` or `cancel` must have an explicit id",
+  );
+});
+
+Deno.test("a background step with a pinned uses round-trips", () => {
+  setup();
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [
+          step({ id: "svc", uses: "actions/service@v1", background: true }),
+          step({ name: "Test", run: "npm test" }),
+        ],
+      },
+    ],
+  });
+
+  const original = wf.toYamlString();
+  const { content: pinned } = pinYamlContent(original, () => "a".repeat(40));
+  const unpinned = unpinParsedYaml(parse(pinned), parsePinComments(pinned));
+  assertEquals(JSON.stringify(unpinned), JSON.stringify(parse(original)));
+});
+
 // --- step with if condition ---
 
 Deno.test("step with if condition appears in YAML", () => {

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -1187,6 +1187,247 @@ Deno.test("pin/unpin round-trips a uses nested in a parallel block", () => {
   assertEquals(JSON.stringify(unpinned), JSON.stringify(parse(original)));
 });
 
+// --- background steps ---
+
+Deno.test("background step and step.waitFor wait on it by id", () => {
+  setup();
+  const server = step({
+    id: "server",
+    name: "Start server",
+    run: "npm start",
+    background: true,
+  });
+  const tests = step.comesAfter(server)({ name: "Run tests", run: "npm test" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [server, tests, step.waitFor(server)],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start server
+        id: server
+        run: npm start
+        background: true
+      - name: Run tests
+        run: npm test
+      - wait: server
+`,
+  );
+});
+
+Deno.test("step.waitFor on multiple steps serializes a list", () => {
+  setup();
+  const bf = step({
+    id: "build-frontend",
+    run: "npm run build:frontend",
+    background: true,
+  });
+  const bb = step({
+    id: "build-backend",
+    run: "npm run build:backend",
+    background: true,
+  });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [bf, bb, step.waitFor(bf, bb)],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: build-frontend
+        run: 'npm run build:frontend'
+        background: true
+      - id: build-backend
+        run: 'npm run build:backend'
+        background: true
+      - wait:
+          - build-frontend
+          - build-backend
+`,
+  );
+});
+
+Deno.test("step.waitForAll serializes wait-all", () => {
+  setup();
+  const db = step({
+    id: "db",
+    run: "docker run -d postgres",
+    background: true,
+  });
+  const it = step({ name: "IT", run: "npm run it" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [db, it, step.waitForAll()],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: db
+        run: docker run -d postgres
+        background: true
+      - name: IT
+        run: npm run it
+      - wait-all: null
+`,
+  );
+});
+
+Deno.test("step.cancel terminates a background step by id", () => {
+  setup();
+  const monitor = step({
+    id: "monitor",
+    run: "./monitor.sh",
+    background: true,
+  });
+  const main = step({ name: "Main", run: "npm test" });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [monitor, main, step.cancel(monitor)],
+      },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: monitor
+        run: ./monitor.sh
+        background: true
+      - name: Main
+        run: npm test
+      - cancel: monitor
+`,
+  );
+});
+
+Deno.test("step.waitFor pulls in the referenced step when not listed", () => {
+  setup();
+  const server = step({ id: "server", run: "npm start", background: true });
+
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      { id: "j", runsOn: "ubuntu-latest", steps: [step.waitFor(server)] },
+    ],
+  });
+
+  assertEquals(
+    wf.toYamlString(),
+    `name: test
+on: {}
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: npm start
+        background: true
+      - wait: server
+`,
+  );
+});
+
+Deno.test("step.waitFor() with no args throws", () => {
+  assertThrows(
+    () => step.waitFor(),
+    Error,
+    "step.waitFor() requires at least one step",
+  );
+});
+
+Deno.test("step.waitFor requires the referenced step to have an id", () => {
+  assertThrows(
+    () => step.waitFor(step({ name: "x", run: "x", background: true })),
+    Error,
+    "step.waitFor() requires each referenced step to have an explicit id",
+  );
+});
+
+Deno.test("step.cancel requires the referenced step to have an id", () => {
+  assertThrows(
+    () => step.cancel(step({ name: "x", run: "x", background: true })),
+    Error,
+    "step.cancel() requires the referenced step to have an explicit id",
+  );
+});
+
+Deno.test("a wait config referencing a step without an id throws at serialization", () => {
+  setup();
+  const noId = step({ name: "No id", run: "x", background: true });
+  const wf = workflow({
+    name: "test",
+    on: {},
+    jobs: [
+      {
+        id: "j",
+        runsOn: "ubuntu-latest",
+        steps: [noId, step({ name: "Wait", wait: noId })],
+      },
+    ],
+  });
+
+  assertThrows(
+    () => wf.toYamlString(),
+    Error,
+    "a step referenced by `wait` or `cancel` must have an explicit id",
+  );
+});
+
 // --- step with if condition ---
 
 Deno.test("step with if condition appears in YAML", () => {

--- a/src/step.ts
+++ b/src/step.ts
@@ -95,6 +95,7 @@ export class Step<O extends string = never> implements ExpressionSource {
         "Step with outputs must have an explicit id",
       );
     }
+    assertStepShape(config);
 
     this.#id = config.id ?? `_step_${stepCounter++}`;
     this.config = config;
@@ -195,7 +196,7 @@ export class Step<O extends string = never> implements ExpressionSource {
       const refs = Array.isArray(this.config.wait)
         ? this.config.wait
         : [this.config.wait];
-      const ids = refs.map(waitCancelTargetId);
+      const ids = [...new Set(refs.map(waitCancelTargetId))];
       result.wait = ids.length === 1 ? ids[0] : ids;
     }
 
@@ -333,17 +334,18 @@ export interface StepFunction {
   ): Step<string>;
   /**
    * Creates a `wait` step that blocks until the given background step(s)
-   * finish. The referenced steps are ordered before this one and must each
-   * have an explicit `id`.
+   * finish. The referenced steps are ordered before this one and must each be
+   * a background step with an explicit `id`.
    */
-  waitFor(...steps: StepLike[]): StepRef<string>;
+  waitFor(...steps: (Step<string> | StepRef<string>)[]): StepRef<string>;
   /** Creates a `wait-all` step that blocks until all background steps finish. */
   waitForAll(): Step<string>;
   /**
    * Creates a `cancel` step that terminates the given background step. The
-   * referenced step is ordered before this one and must have an explicit `id`.
+   * referenced step is ordered before this one and must be a background step
+   * with an explicit `id`.
    */
-  cancel(target: StepLike): StepRef<string>;
+  cancel(target: Step<string> | StepRef<string>): StepRef<string>;
 }
 
 export const step: StepFunction = Object.assign(
@@ -357,41 +359,51 @@ export const step: StepFunction = Object.assign(
       createStepBuilder({ afterDependencies: deps }),
     parallel: (...args: unknown[]): Step<string> =>
       buildParallelFromArgs(...args),
-    waitFor: (...steps: StepLike[]): StepRef<string> => buildWaitFor(...steps),
+    waitFor: (...steps: (Step<string> | StepRef<string>)[]): StepRef<string> =>
+      buildWaitFor(...steps),
     waitForAll: (): Step<string> => new Step<string>({ waitAll: true }),
-    cancel: (target: StepLike): StepRef<string> => buildCancel(target),
+    cancel: (target: Step<string> | StepRef<string>): StepRef<string> =>
+      buildCancel(target),
   },
 );
 
 /** Builds a `wait` step that depends on (and orders after) its targets. */
-function buildWaitFor(...steps: StepLike[]): StepRef<string> {
+function buildWaitFor(
+  ...steps: (Step<string> | StepRef<string>)[]
+): StepRef<string> {
   if (steps.length === 0) {
     throw new Error("step.waitFor() requires at least one step");
   }
-  const resolved = steps.map(unwrapStep);
-  for (const s of resolved) {
-    if (!s.config.id) {
-      throw new Error(
-        "step.waitFor() requires each referenced step to have an explicit id",
-      );
-    }
+  for (const s of steps) {
+    assertWaitCancelTarget(s, "step.waitFor()", "each referenced step");
   }
-  return new StepRef<string>(new Step<string>({ wait: resolved }), {
-    dependencies: resolved,
+  // keep the original Step/StepRef so the target's own deps are preserved
+  return new StepRef<string>(new Step<string>({ wait: steps }), {
+    dependencies: steps,
   });
 }
 
 /** Builds a `cancel` step that depends on (and orders after) its target. */
-function buildCancel(target: StepLike): StepRef<string> {
-  const resolved = unwrapStep(target);
-  if (!resolved.config.id) {
-    throw new Error(
-      "step.cancel() requires the referenced step to have an explicit id",
-    );
-  }
-  return new StepRef<string>(new Step<string>({ cancel: resolved }), {
-    dependencies: [resolved],
+function buildCancel(target: Step<string> | StepRef<string>): StepRef<string> {
+  assertWaitCancelTarget(target, "step.cancel()", "the referenced step");
+  return new StepRef<string>(new Step<string>({ cancel: target }), {
+    dependencies: [target],
   });
+}
+
+/** Validates a `waitFor`/`cancel` target: a background step with an explicit id. */
+function assertWaitCancelTarget(
+  target: Step<string> | StepRef<string>,
+  call: string,
+  subject: string,
+): void {
+  const step = unwrapStep(target);
+  if (!step.config.id) {
+    throw new Error(`${call} requires ${subject} to have an explicit id`);
+  }
+  if (!step.config.background) {
+    throw new Error(`${call} can only target a background step`);
+  }
 }
 
 /** Builds a parallel composite step from the given args. */
@@ -467,6 +479,35 @@ export class StepRef<O extends string = never> {
 }
 
 // --- serialization helpers ---
+
+/**
+ * Validates that a step does not combine mutually exclusive control keys.
+ * `wait`, `wait-all`, and `cancel` are distinct step kinds — each must stand
+ * alone (a step that waits or cancels does no work of its own).
+ */
+function assertStepShape(config: StepConfig<string>): void {
+  const controlKeys: string[] = [];
+  if (config.wait != null) controlKeys.push("wait");
+  if (config.waitAll) controlKeys.push("wait-all");
+  if (config.cancel != null) controlKeys.push("cancel");
+  if (controlKeys.length > 1) {
+    throw new Error(
+      `A step cannot combine ${controlKeys.join(", ")} — ` +
+        "wait, wait-all, and cancel are mutually exclusive.",
+    );
+  }
+  if (controlKeys.length === 1) {
+    const work: string[] = [];
+    if (config.run != null) work.push("run");
+    if (config.uses != null) work.push("uses");
+    if (config.background) work.push("background");
+    if (work.length > 0) {
+      throw new Error(
+        `A ${controlKeys[0]} step cannot also have ${work.join(", ")}.`,
+      );
+    }
+  }
+}
 
 /** Resolves the explicit id of a step referenced by `wait`/`cancel`. */
 function waitCancelTargetId(item: StepLike): string {

--- a/src/step.ts
+++ b/src/step.ts
@@ -23,6 +23,23 @@ export interface StepConfig<O extends string = never> {
   readonly continueOnError?: boolean | string;
   readonly timeoutMinutes?: number;
   readonly outputs?: readonly O[];
+  /** Runs the step asynchronously so the job continues without waiting for it. */
+  readonly background?: boolean;
+  /**
+   * Makes this a `wait` step that blocks until the referenced background
+   * step(s) finish. Prefer `step.waitFor(...)`, which also wires up ordering.
+   */
+  readonly wait?: StepLike | readonly StepLike[];
+  /**
+   * Makes this a `wait-all` step that blocks until all active background steps
+   * finish. Prefer `step.waitForAll()`.
+   */
+  readonly waitAll?: boolean;
+  /**
+   * Makes this a `cancel` step that terminates the referenced background step.
+   * Prefer `step.cancel(...)`, which also wires up ordering.
+   */
+  readonly cancel?: StepLike;
 }
 
 let stepCounter = 0;
@@ -170,6 +187,26 @@ export class Step<O extends string = never> implements ExpressionSource {
         : this.config.run;
     }
 
+    if (this.config.background) {
+      result.background = true;
+    }
+
+    if (this.config.wait != null) {
+      const refs = Array.isArray(this.config.wait)
+        ? this.config.wait
+        : [this.config.wait];
+      const ids = refs.map(waitCancelTargetId);
+      result.wait = ids.length === 1 ? ids[0] : ids;
+    }
+
+    if (this.config.waitAll) {
+      result["wait-all"] = null;
+    }
+
+    if (this.config.cancel != null) {
+      result.cancel = waitCancelTargetId(this.config.cancel);
+    }
+
     return result;
   }
 }
@@ -294,6 +331,19 @@ export interface StepFunction {
   parallel(
     ...args: (StepConfig | Step<string> | StepRef<string>)[]
   ): Step<string>;
+  /**
+   * Creates a `wait` step that blocks until the given background step(s)
+   * finish. The referenced steps are ordered before this one and must each
+   * have an explicit `id`.
+   */
+  waitFor(...steps: StepLike[]): StepRef<string>;
+  /** Creates a `wait-all` step that blocks until all background steps finish. */
+  waitForAll(): Step<string>;
+  /**
+   * Creates a `cancel` step that terminates the given background step. The
+   * referenced step is ordered before this one and must have an explicit `id`.
+   */
+  cancel(target: StepLike): StepRef<string>;
 }
 
 export const step: StepFunction = Object.assign(
@@ -307,8 +357,42 @@ export const step: StepFunction = Object.assign(
       createStepBuilder({ afterDependencies: deps }),
     parallel: (...args: unknown[]): Step<string> =>
       buildParallelFromArgs(...args),
+    waitFor: (...steps: StepLike[]): StepRef<string> => buildWaitFor(...steps),
+    waitForAll: (): Step<string> => new Step<string>({ waitAll: true }),
+    cancel: (target: StepLike): StepRef<string> => buildCancel(target),
   },
 );
+
+/** Builds a `wait` step that depends on (and orders after) its targets. */
+function buildWaitFor(...steps: StepLike[]): StepRef<string> {
+  if (steps.length === 0) {
+    throw new Error("step.waitFor() requires at least one step");
+  }
+  const resolved = steps.map(unwrapStep);
+  for (const s of resolved) {
+    if (!s.config.id) {
+      throw new Error(
+        "step.waitFor() requires each referenced step to have an explicit id",
+      );
+    }
+  }
+  return new StepRef<string>(new Step<string>({ wait: resolved }), {
+    dependencies: resolved,
+  });
+}
+
+/** Builds a `cancel` step that depends on (and orders after) its target. */
+function buildCancel(target: StepLike): StepRef<string> {
+  const resolved = unwrapStep(target);
+  if (!resolved.config.id) {
+    throw new Error(
+      "step.cancel() requires the referenced step to have an explicit id",
+    );
+  }
+  return new StepRef<string>(new Step<string>({ cancel: resolved }), {
+    dependencies: [resolved],
+  });
+}
 
 /** Builds a parallel composite step from the given args. */
 function buildParallelFromArgs(...args: unknown[]): Step<string> {
@@ -383,6 +467,17 @@ export class StepRef<O extends string = never> {
 }
 
 // --- serialization helpers ---
+
+/** Resolves the explicit id of a step referenced by `wait`/`cancel`. */
+function waitCancelTargetId(item: StepLike): string {
+  const step = unwrapStep(item);
+  if (!step.config.id) {
+    throw new Error(
+      "a step referenced by `wait` or `cancel` must have an explicit id",
+    );
+  }
+  return step.config.id;
+}
 
 export function serializeConditionLike(c: ConditionLike): string {
   if (c instanceof Condition) {


### PR DESCRIPTION
Adds the lower-level GitHub Actions step-concurrency primitives that `parallel` is sugar for.

## API

| API | YAML |
|---|---|
| `step({ background: true, ... })` | `background: true` |
| `step.waitFor(a)` / `step.waitFor(a, b)` | `wait: a` / `wait: [a, b]` |
| `step.waitForAll()` | `wait-all:` |
| `step.cancel(a)` | `cancel: a` |

A long-running service is started in the background, used, then stopped with `cancel`:

```ts
const server = step({ id: "server", name: "Start server", run: "npm start", background: true });

workflow({
  ...,
  jobs: [{
    id: "e2e",
    runsOn: "ubuntu-latest",
    steps: [server, step({ name: "Run tests", run: "npm test" }), step.cancel(server)],
  }],
});
```

`step.waitFor()` is for background work that finishes — kick it off, do other work while it runs, then block on it before the step that needs it.

- `waitFor`/`cancel` order after — and pull in — the steps they reference (incl. transitive deps), and require the target to be a **background step with an explicit `id`**.
- Validation throws on nonsensical shapes: combining `wait`/`wait-all`/`cancel` with each other or with `run`/`uses`/`background`, and using a background/wait/cancel step as a `parallel` member.

## Notes
- `step.waitForAll()` serializes as `wait-all: null`, which is YAML-equivalent to the docs' bare `wait-all:` (both parse to null, so GitHub and `--lint` treat them identically).
- The 10-concurrent-background-step limit is a runtime GitHub limit; gagen documents it but can't enforce it.

## Tests
Covers each primitive, the multi-`wait` list form, transitive-dep pull-in, dedup, conditioned wait steps, id-less background, `background` on a `uses:` step, config-form serialization, modifiers on results, a pin round-trip, and every validation error. Full suite: 379 passing; fmt/lint/type-check clean.

Reviewed by a multi-agent pass; the bugs it surfaced (dropped transitive deps, duplicate ids) and missing guards are fixed in the hardening commit.

Closes https://github.com/dsherret/gagen/issues/40
