### PR TITLE
refactor!: key internal members by symbols so they are not public API

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -1,3 +1,4 @@
+import * as internal from "./internal.ts";
 import fs from "node:fs";
 import { stringify } from "@std/yaml/stringify";
 import { ExpressionValue } from "./expression.ts";
@@ -66,7 +67,7 @@ export class ActionInputs<_K extends string> {
   }
 
   /** Serializes the input definitions to their YAML form. */
-  toYaml(): Record<string, unknown> {
+  [internal.toYaml](): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     const defs = inputDefs.get(this as ActionInputs<string>) ?? {};
     for (const [name, def] of Object.entries(defs)) {
@@ -128,7 +129,7 @@ export class Action {
     }
 
     if (config.inputs != null) {
-      const inputs = config.inputs.toYaml();
+      const inputs = config.inputs[internal.toYaml]();
       if (Object.keys(inputs).length > 0) {
         obj.inputs = inputs;
       }
@@ -146,7 +147,7 @@ export class Action {
       steps: Array.isArray(config.steps) ? config.steps : [config.steps],
       outputs: stepOutputs,
     });
-    const { steps, outputs } = job.toStepsYaml(
+    const { steps, outputs } = job[internal.toStepsYaml](
       `Action "${config.name}"`,
       "action",
     );
@@ -248,7 +249,7 @@ function applyRunDefaults(
  * step that set them itself.
  *
  * `shell` counts as a header key so that a default `working-directory` lands
- * after a shell the step set itself, matching the order `Step.toYaml` uses.
+ * after a shell the step set itself, matching the order steps serialize in.
  */
 function insertAfterHeader(
   step: Record<string, unknown>,

--- a/src/action_test.ts
+++ b/src/action_test.ts
@@ -266,9 +266,9 @@ Deno.test("defineInputs exposes typed input expressions", () => {
 
 Deno.test("defineInputs rejects an input that shadows a member", () => {
   assertThrows(
-    () => defineInputs({ toYaml: { description: "x" } }),
+    () => defineInputs({ constructor: { description: "x" } }),
     Error,
-    'Input "toYaml" conflicts with an ActionInputs member',
+    'Input "constructor" conflicts with an ActionInputs member',
   );
 });
 

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -1,3 +1,5 @@
+import * as internal from "./internal.ts";
+
 // types that step/job/workflow will reference back to
 
 /** Something an expression can depend on, such as a step or a job. */
@@ -14,7 +16,7 @@ export type TernaryValue = string | number | boolean | ExpressionValue;
  */
 export class ExpressionValue {
   readonly #expression: string;
-  readonly source: ExpressionSource | undefined;
+  readonly [internal.source]: ExpressionSource | undefined;
   readonly #allSources: ReadonlySet<ExpressionSource>;
 
   constructor(
@@ -23,17 +25,17 @@ export class ExpressionValue {
   ) {
     this.#expression = expression;
     if (source instanceof Set) {
-      this.source = undefined;
+      this[internal.source] = undefined;
       this.#allSources = source as ReadonlySet<ExpressionSource>;
     } else {
       const s = source as ExpressionSource | undefined;
-      this.source = s;
+      this[internal.source] = s;
       this.#allSources = s ? new Set([s]) : EMPTY_SOURCES;
     }
   }
 
   /** all expression sources referenced by this value */
-  get allSources(): ReadonlySet<ExpressionSource> {
+  get [internal.allSources](): ReadonlySet<ExpressionSource> {
     return this.#allSources;
   }
 
@@ -213,17 +215,17 @@ export abstract class Condition {
    * Returns the flat AND terms of this condition. Used by condition
    * simplification to detect absorption (A || A && B → A).
    */
-  getAndTerms(): string[] {
+  [internal.getAndTerms](): string[] {
     return [this.toExpression()];
   }
 
   /** returns the flat AND children of this condition as Condition objects */
-  flattenAnd(): Condition[] {
+  [internal.flattenAnd](): Condition[] {
     return [this];
   }
 
   /** returns the flat OR children of this condition as Condition objects */
-  flattenOr(): Condition[] {
+  [internal.flattenOr](): Condition[] {
     return [this];
   }
 
@@ -247,7 +249,9 @@ export abstract class Condition {
    * given sources. Simplification uses this when it drops a duplicate term
    * whose sources the surviving term doesn't already have.
    */
-  abstract withSources(sources: ReadonlySet<ExpressionSource>): Condition;
+  abstract [internal.withSources](
+    sources: ReadonlySet<ExpressionSource>,
+  ): Condition;
 
   /** render without `${{ }}` wrapping */
   abstract toExpression(): string;
@@ -299,7 +303,7 @@ export class ComparisonCondition extends Condition {
     );
   }
 
-  override withSources(
+  override [internal.withSources](
     sources: ReadonlySet<ExpressionSource>,
   ): ComparisonCondition {
     return new ComparisonCondition(
@@ -335,7 +339,7 @@ export class FunctionCallCondition extends Condition {
     this.#args = args;
   }
 
-  override withSources(
+  override [internal.withSources](
     sources: ReadonlySet<ExpressionSource>,
   ): FunctionCallCondition {
     return new FunctionCallCondition(
@@ -369,28 +373,37 @@ class LogicalCondition extends Condition {
     this.#right = right;
   }
 
-  override getAndTerms(): string[] {
+  override [internal.getAndTerms](): string[] {
     if (this.op === "&&") {
-      return [...this.#left.getAndTerms(), ...this.#right.getAndTerms()];
+      return [
+        ...this.#left[internal.getAndTerms](),
+        ...this.#right[internal.getAndTerms](),
+      ];
     }
     return [this.toExpression()];
   }
 
-  override flattenAnd(): Condition[] {
+  override [internal.flattenAnd](): Condition[] {
     if (this.op === "&&") {
-      return [...this.#left.flattenAnd(), ...this.#right.flattenAnd()];
+      return [
+        ...this.#left[internal.flattenAnd](),
+        ...this.#right[internal.flattenAnd](),
+      ];
     }
     return [this];
   }
 
-  override flattenOr(): Condition[] {
+  override [internal.flattenOr](): Condition[] {
     if (this.op === "||") {
-      return [...this.#left.flattenOr(), ...this.#right.flattenOr()];
+      return [
+        ...this.#left[internal.flattenOr](),
+        ...this.#right[internal.flattenOr](),
+      ];
     }
     return [this];
   }
 
-  override withSources(
+  override [internal.withSources](
     sources: ReadonlySet<ExpressionSource>,
   ): LogicalCondition {
     return new LogicalCondition(
@@ -437,7 +450,9 @@ class NotCondition extends Condition {
     return this.#inner;
   }
 
-  override withSources(sources: ReadonlySet<ExpressionSource>): NotCondition {
+  override [internal.withSources](
+    sources: ReadonlySet<ExpressionSource>,
+  ): NotCondition {
     return new NotCondition(this.#inner, mergeSources(this.sources, sources));
   }
 
@@ -479,7 +494,9 @@ export class RawCondition extends Condition {
     return super.not();
   }
 
-  override withSources(sources: ReadonlySet<ExpressionSource>): RawCondition {
+  override [internal.withSources](
+    sources: ReadonlySet<ExpressionSource>,
+  ): RawCondition {
     return new RawCondition(
       this.#expression,
       mergeSources(this.sources, sources),
@@ -638,16 +655,14 @@ export function formatLiteral(value: string | number | boolean): string {
 
 /** Collects the sources of any number of expression values or conditions. */
 export function sourcesFrom(
-  ...sourceables: ({ source?: ExpressionSource } | Condition)[]
+  ...sourceables: (ExpressionValue | Condition)[]
 ): ReadonlySet<ExpressionSource> {
   const set = new Set<ExpressionSource>();
   for (const v of sourceables) {
     if (v instanceof Condition) {
       for (const s of v.sources) set.add(s);
-    } else if (v instanceof ExpressionValue) {
-      for (const s of v.allSources) set.add(s);
-    } else if (v.source) {
-      set.add(v.source);
+    } else {
+      for (const s of v[internal.allSources]) set.add(s);
     }
   }
   return set;
@@ -767,19 +782,25 @@ function deduplicatedLogical(
   left: Condition,
   right: Condition,
 ): Condition {
-  const leftTerms = op === "&&" ? left.flattenAnd() : left.flattenOr();
-  const rightTerms = op === "&&" ? right.flattenAnd() : right.flattenOr();
+  const leftTerms = op === "&&"
+    ? left[internal.flattenAnd]()
+    : left[internal.flattenOr]();
+  const rightTerms = op === "&&"
+    ? right[internal.flattenAnd]()
+    : right[internal.flattenOr]();
   const seen = new Set(leftTerms.map((t) => t.toExpression()));
   const unique = rightTerms.filter((t) => !seen.has(t.toExpression()));
   // every right term already appears on the left, so the left side is the
   // whole result, but it still has to pick up the right side's sources
-  if (unique.length === 0) return left.withSources(right.sources);
+  if (unique.length === 0) return left[internal.withSources](right.sources);
   const allTerms = [...leftTerms, ...unique];
   // absorption: for &&, drop any OR compound whose child appears as a sibling
   // term (e.g. (A || B) && B → B). Symmetrically for ||.
   const termExprs = new Set(allTerms.map((t) => t.toExpression()));
   const absorbed = allTerms.filter((term) => {
-    const children = op === "&&" ? term.flattenOr() : term.flattenAnd();
+    const children = op === "&&"
+      ? term[internal.flattenOr]()
+      : term[internal.flattenAnd]();
     if (children.length <= 1) return true;
     return !children.some((c) => termExprs.has(c.toExpression()));
   });
@@ -806,7 +827,7 @@ function collectTernarySources(
   for (const { condition, value } of branches) {
     for (const s of condition.sources) set.add(s);
     if (value instanceof ExpressionValue) {
-      for (const s of value.allSources) set.add(s);
+      for (const s of value[internal.allSources]) set.add(s);
     }
   }
   return set;
@@ -893,7 +914,7 @@ export class ThenBuilder {
   else(value: TernaryValue): ExpressionValue {
     const sources = new Set(this.#sources);
     if (value instanceof ExpressionValue) {
-      for (const s of value.allSources) sources.add(s);
+      for (const s of value[internal.allSources]) sources.add(s);
     }
 
     const parts: string[] = [];
@@ -979,7 +1000,7 @@ export function concat(...parts: ConcatPart[]): ExpressionValue {
   const flat: (string | ExpressionValue)[] = [];
   for (const part of parts) {
     if (part instanceof ConcatValue) {
-      flat.push(...part.concatParts);
+      flat.push(...part[internal.concatParts]);
     } else if (part instanceof InlineValue) {
       flat.push(part.toString());
     } else if (typeof part === "number") {
@@ -1011,7 +1032,7 @@ export function concat(...parts: ConcatPart[]): ExpressionValue {
   const sources = new Set<ExpressionSource>();
   for (const part of merged) {
     if (part instanceof ExpressionValue) {
-      for (const s of part.allSources) sources.add(s);
+      for (const s of part[internal.allSources]) sources.add(s);
     }
   }
 
@@ -1048,7 +1069,10 @@ class ConcatValue extends ExpressionValue {
   }
 
   /** the individual parts of this concatenation (for flattening nested concats) */
-  get concatParts(): readonly (string | ExpressionValue)[] {
+  get [internal.concatParts](): readonly (
+    | string
+    | ExpressionValue
+  )[] {
     return this.#parts;
   }
 
@@ -1075,7 +1099,7 @@ export function fromJSON(value: string | ExpressionValue): ExpressionValue {
     return new ExpressionValue(`fromJSON(${formatLiteral(value)})`);
   }
   const sources = new Set<ExpressionSource>();
-  for (const s of value.allSources) sources.add(s);
+  for (const s of value[internal.allSources]) sources.add(s);
   return new ExpressionValue(`fromJSON(${value.expression})`, sources);
 }
 
@@ -1090,7 +1114,7 @@ export function fromJSON(value: string | ExpressionValue): ExpressionValue {
  */
 export function toJSON(value: ExpressionValue): ExpressionValue {
   const sources = new Set<ExpressionSource>();
-  for (const s of value.allSources) sources.add(s);
+  for (const s of value[internal.allSources]) sources.add(s);
   return new ExpressionValue(`toJSON(${value.expression})`, sources);
 }
 
@@ -1107,7 +1131,7 @@ export function hashFiles(
   const args: string[] = [];
   for (const p of patterns) {
     if (p instanceof ExpressionValue) {
-      for (const s of p.allSources) sources.add(s);
+      for (const s of p[internal.allSources]) sources.add(s);
       args.push(p.expression);
     } else {
       args.push(formatLiteral(p));
@@ -1135,7 +1159,7 @@ export function join(
   separator?: string,
 ): ExpressionValue {
   const sources = new Set<ExpressionSource>();
-  for (const s of value.allSources) sources.add(s);
+  for (const s of value[internal.allSources]) sources.add(s);
   const args = separator != null
     ? `${value.expression}, ${formatLiteral(separator)}`
     : value.expression;

--- a/src/expression_test.ts
+++ b/src/expression_test.ts
@@ -1,3 +1,4 @@
+import * as internal from "./internal.ts";
 import { assertEquals, assertThrows } from "@std/assert";
 import {
   ComparisonCondition,
@@ -134,14 +135,14 @@ Deno.test("ExpressionValue chaining or().and() from values", () => {
 
 Deno.test("ExpressionValue no source by default", () => {
   const v = new ExpressionValue("github.ref");
-  assertEquals(v.source, undefined);
+  assertEquals(v[internal.source], undefined);
   assertEquals(v.equals("main").sources.size, 0);
 });
 
 Deno.test("ExpressionValue source flows into equals", () => {
   const src = { id: "step_1" };
   const v = new ExpressionValue("steps.check.outputs.result", src);
-  assertEquals(v.source, src);
+  assertEquals(v[internal.source], src);
   const c = v.equals("success");
   assertEquals(c.sources.size, 1);
   assertEquals(c.sources.has(src), true);
@@ -796,9 +797,9 @@ Deno.test("concat tracks sources from all expressions", () => {
   const v1 = new ExpressionValue("steps.a.outputs.x", s1);
   const v2 = new ExpressionValue("steps.b.outputs.y", s2);
   const v = concat("prefix-", v1, "-", v2);
-  assertEquals(v.allSources.size, 2);
-  assertEquals(v.allSources.has(s1), true);
-  assertEquals(v.allSources.has(s2), true);
+  assertEquals(v[internal.allSources].size, 2);
+  assertEquals(v[internal.allSources].has(s1), true);
+  assertEquals(v[internal.allSources].has(s2), true);
 });
 
 Deno.test("concat result works with .equals()", () => {
@@ -936,8 +937,8 @@ Deno.test("fromJSON tracks sources", () => {
   const s = { id: "s1" };
   const v = new ExpressionValue("needs.setup.outputs.matrix", s);
   const result = fromJSON(v);
-  assertEquals(result.allSources.size, 1);
-  assertEquals(result.allSources.has(s), true);
+  assertEquals(result[internal.allSources].size, 1);
+  assertEquals(result[internal.allSources].has(s), true);
 });
 
 // --- toJSON ---
@@ -952,8 +953,8 @@ Deno.test("toJSON tracks sources", () => {
   const s = { id: "s1" };
   const v = new ExpressionValue("steps.a.outputs.data", s);
   const result = toJSON(v);
-  assertEquals(result.allSources.size, 1);
-  assertEquals(result.allSources.has(s), true);
+  assertEquals(result[internal.allSources].size, 1);
+  assertEquals(result[internal.allSources].has(s), true);
 });
 
 Deno.test("ExpressionValue.toJSON() method", () => {
@@ -987,8 +988,8 @@ Deno.test("hashFiles tracks sources from expression patterns", () => {
   const s = { id: "s1" };
   const v = new ExpressionValue("steps.a.outputs.pattern", s);
   const result = hashFiles(v);
-  assertEquals(result.allSources.size, 1);
-  assertEquals(result.allSources.has(s), true);
+  assertEquals(result[internal.allSources].size, 1);
+  assertEquals(result[internal.allSources].has(s), true);
 });
 
 Deno.test("hashFiles result works with concat for cache keys", () => {
@@ -1024,8 +1025,8 @@ Deno.test("join tracks sources", () => {
   const s = { id: "s1" };
   const v = new ExpressionValue("steps.a.outputs.list", s);
   const result = join(v, ",");
-  assertEquals(result.allSources.size, 1);
-  assertEquals(result.allSources.has(s), true);
+  assertEquals(result[internal.allSources].size, 1);
+  assertEquals(result[internal.allSources].has(s), true);
 });
 
 Deno.test("join with an empty separator", () => {
@@ -1363,10 +1364,10 @@ Deno.test("ternary collects sources from conditions and values", () => {
   const v = cmp("a", "1", [s1])
     .then(new ExpressionValue("steps.b.outputs.x", s2))
     .else(new ExpressionValue("steps.c.outputs.y", s3));
-  assertEquals(v.allSources.size, 3);
-  assertEquals(v.allSources.has(s1), true);
-  assertEquals(v.allSources.has(s2), true);
-  assertEquals(v.allSources.has(s3), true);
+  assertEquals(v[internal.allSources].size, 3);
+  assertEquals(v[internal.allSources].has(s1), true);
+  assertEquals(v[internal.allSources].has(s2), true);
+  assertEquals(v[internal.allSources].has(s3), true);
 });
 
 Deno.test("ternary collects sources from elseIf branches", () => {
@@ -1377,14 +1378,14 @@ Deno.test("ternary collects sources from elseIf branches", () => {
     .elseIf(cmp("b", "2", [s2]))
     .then("y")
     .else("z");
-  assertEquals(v.allSources.size, 2);
+  assertEquals(v[internal.allSources].size, 2);
 });
 
 Deno.test("elseIf does not leak sources into the builder it came from", () => {
   const s2 = { id: "s2" };
   const builder = cmp("a", "1").then("x");
   builder.elseIf(cmp("b", "2", [s2]));
-  assertEquals(builder.else("z").allSources.size, 0);
+  assertEquals(builder.else("z")[internal.allSources].size, 0);
 });
 
 Deno.test("ternary can be used as a concat part", () => {
@@ -1521,19 +1522,16 @@ Deno.test("isPossiblyTrue reflects always-false", () => {
 
 // --- sourcesFrom ---
 
-Deno.test("sourcesFrom collects from values, conditions, and sourceables", () => {
+Deno.test("sourcesFrom collects from values and conditions", () => {
   const s1 = { id: "s1" };
   const s2 = { id: "s2" };
-  const s3 = { id: "s3" };
   const set = sourcesFrom(
     new ExpressionValue("a", s1),
     cmp("b", "2", [s2]),
-    { source: s3 },
   );
-  assertEquals(set.size, 3);
+  assertEquals(set.size, 2);
   assertEquals(set.has(s1), true);
   assertEquals(set.has(s2), true);
-  assertEquals(set.has(s3), true);
 });
 
 Deno.test("sourcesFrom deduplicates and tolerates missing sources", () => {
@@ -1541,7 +1539,7 @@ Deno.test("sourcesFrom deduplicates and tolerates missing sources", () => {
   const set = sourcesFrom(
     new ExpressionValue("a", s1),
     new ExpressionValue("b", s1),
-    { source: undefined },
+    new ExpressionValue("c"),
   );
   assertEquals(set.size, 1);
 });
@@ -1550,8 +1548,8 @@ Deno.test("ExpressionValue built from a source set has no single source", () => 
   const s1 = { id: "s1" };
   const s2 = { id: "s2" };
   const v = new ExpressionValue("a", new Set([s1, s2]));
-  assertEquals(v.source, undefined);
-  assertEquals(v.allSources.size, 2);
+  assertEquals(v[internal.source], undefined);
+  assertEquals(v[internal.allSources].size, 2);
   assertEquals(v.equals("x").sources.size, 2);
 });
 
@@ -1559,30 +1557,30 @@ Deno.test("ExpressionValue built from a source set has no single source", () => 
 
 Deno.test("flattenAnd flattens nested ands only", () => {
   const c = cmp("a", "1").and(cmp("b", "2")).and(cmp("c", "3"));
-  assertEquals(c.flattenAnd().map((t) => t.toExpression()), [
+  assertEquals(c[internal.flattenAnd]().map((t) => t.toExpression()), [
     "a == '1'",
     "b == '2'",
     "c == '3'",
   ]);
-  assertEquals(c.flattenOr().length, 1);
+  assertEquals(c[internal.flattenOr]().length, 1);
 });
 
 Deno.test("flattenOr flattens nested ors only", () => {
   const c = cmp("a", "1").or(cmp("b", "2")).or(cmp("c", "3"));
-  assertEquals(c.flattenOr().map((t) => t.toExpression()), [
+  assertEquals(c[internal.flattenOr]().map((t) => t.toExpression()), [
     "a == '1'",
     "b == '2'",
     "c == '3'",
   ]);
-  assertEquals(c.flattenAnd().length, 1);
+  assertEquals(c[internal.flattenAnd]().length, 1);
 });
 
 Deno.test("getAndTerms returns and terms but not or terms", () => {
-  assertEquals(cmp("a", "1").and(cmp("b", "2")).getAndTerms(), [
+  assertEquals(cmp("a", "1").and(cmp("b", "2"))[internal.getAndTerms](), [
     "a == '1'",
     "b == '2'",
   ]);
-  assertEquals(cmp("a", "1").or(cmp("b", "2")).getAndTerms(), [
+  assertEquals(cmp("a", "1").or(cmp("b", "2"))[internal.getAndTerms](), [
     "a == '1' || b == '2'",
   ]);
 });
@@ -1634,8 +1632,8 @@ Deno.test("or keeps sources when every right term is already present", () => {
 Deno.test("withSources returns the same condition when nothing is added", () => {
   const s1 = { id: "s1" };
   const c = cmp("a", "1", [s1]);
-  assertEquals(c.withSources(new Set([s1])), c);
-  assertEquals(c.withSources(new Set()), c);
+  assertEquals(c[internal.withSources](new Set([s1])), c);
+  assertEquals(c[internal.withSources](new Set()), c);
 });
 
 Deno.test("withSources preserves rendering for every condition kind", () => {
@@ -1649,7 +1647,7 @@ Deno.test("withSources preserves rendering for every condition kind", () => {
     cmp("a", "1").and(cmp("b", "2")),
   ];
   for (const c of kinds) {
-    const withExtra = c.withSources(extra);
+    const withExtra = c[internal.withSources](extra);
     assertEquals(withExtra.toExpression(), c.toExpression());
     assertEquals(withExtra.sources.has(s), true);
   }
@@ -1715,8 +1713,8 @@ Deno.test("concat preserves sources through nesting", () => {
   const s1 = { id: "s1" };
   const inner = concat("a-", new ExpressionValue("steps.a.outputs.x", s1));
   const outer = concat(inner, "-b");
-  assertEquals(outer.allSources.size, 1);
-  assertEquals(outer.allSources.has(s1), true);
+  assertEquals(outer[internal.allSources].size, 1);
+  assertEquals(outer[internal.allSources].has(s1), true);
 });
 
 Deno.test("concat result can be negated", () => {
@@ -1737,7 +1735,7 @@ Deno.test("fromJSON of toJSON round trips the expression text", () => {
 });
 
 Deno.test("fromJSON of a string carries no sources", () => {
-  assertEquals(fromJSON("[1, 2]").allSources.size, 0);
+  assertEquals(fromJSON("[1, 2]")[internal.allSources].size, 0);
 });
 
 Deno.test("fromJSON result supports comparisons", () => {
@@ -1762,7 +1760,7 @@ Deno.test("hashFiles mixes string and expression patterns", () => {
   const s = { id: "s1" };
   const v = hashFiles("deno.lock", new ExpressionValue("matrix.extra", s));
   assertEquals(v.expression, "hashFiles('deno.lock', matrix.extra)");
-  assertEquals(v.allSources.has(s), true);
+  assertEquals(v[internal.allSources].has(s), true);
 });
 
 // --- defineExprObj error path ---

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,0 +1,43 @@
+/**
+ * Keys for members that the package's modules share but that are not part of
+ * its public API: serialization, dependency-graph plumbing and condition
+ * simplification.
+ *
+ * They are symbols rather than names so that code outside the package cannot
+ * reach them. `mod.ts` does not export this module, and a member keyed by a
+ * symbol that is not in scope cannot be spelled. Inside the package they are
+ * used like any other member: `step[toYaml]()`.
+ */
+
+/** Serializes a step, job, matrix or set of action inputs to its YAML object. */
+export const toYaml: unique symbol = Symbol("gagen.toYaml");
+
+/** Serializes a job's resolved steps and the outputs declared against them. */
+export const toStepsYaml: unique symbol = Symbol("gagen.toStepsYaml");
+
+/** Resolves a job's steps into their final order. */
+export const resolveSteps: unique symbol = Symbol("gagen.resolveSteps");
+
+/** Infers the jobs a job depends on. */
+export const inferNeeds: unique symbol = Symbol("gagen.inferNeeds");
+
+/** The single source an expression value was created from, if any. */
+export const source: unique symbol = Symbol("gagen.source");
+
+/** Every source an expression value references. */
+export const allSources: unique symbol = Symbol("gagen.allSources");
+
+/** The parts of a concatenation, for flattening nested concatenations. */
+export const concatParts: unique symbol = Symbol("gagen.concatParts");
+
+/** The flat AND terms of a condition, as rendered expressions. */
+export const getAndTerms: unique symbol = Symbol("gagen.getAndTerms");
+
+/** The flat AND children of a condition. */
+export const flattenAnd: unique symbol = Symbol("gagen.flattenAnd");
+
+/** The flat OR children of a condition. */
+export const flattenOr: unique symbol = Symbol("gagen.flattenOr");
+
+/** Copies a condition with additional tracked sources. */
+export const withSources: unique symbol = Symbol("gagen.withSources");

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,3 +1,4 @@
+import * as internal from "./internal.ts";
 import {
   Condition,
   type ExpressionSource,
@@ -187,7 +188,7 @@ function propagatableCondition(
     }
   }
   if (condition instanceof ExpressionValue) {
-    for (const source of condition.allSources) {
+    for (const source of condition[internal.allSources]) {
       if (source instanceof Step) return undefined;
     }
   }
@@ -590,7 +591,7 @@ export class Job implements ExpressionSource {
     return { graph, leafSteps, membership };
   }
 
-  resolveSteps(): Step<string>[] {
+  [internal.resolveSteps](): Step<string>[] {
     const { graph, leafSteps } = this.#buildGraph();
     const priority = computePriorities(graph, leafSteps);
     return topoSort(new Set(graph.keys()), priority, graph);
@@ -678,7 +679,7 @@ export class Job implements ExpressionSource {
    * every job referenced by an expression anywhere in the job's configuration
    * or steps. The result is deduplicated and ordered deterministically.
    */
-  inferNeeds(stepOwners?: Map<Step<string>, Job[]>): Job[] {
+  [internal.inferNeeds](stepOwners?: Map<Step<string>, Job[]>): Job[] {
     const config = this.#config;
     const jobSources = new Set<Job>();
 
@@ -715,7 +716,9 @@ export class Job implements ExpressionSource {
   }
 
   /** Serializes the job to its GitHub Actions YAML object representation. */
-  toYaml(stepOwners?: Map<Step<string>, Job[]>): Record<string, unknown> {
+  [internal.toYaml](
+    stepOwners?: Map<Step<string>, Job[]>,
+  ): Record<string, unknown> {
     const config = this.#config;
     const result: Record<string, unknown> = {};
 
@@ -725,7 +728,7 @@ export class Job implements ExpressionSource {
         : config.name;
     }
 
-    const needs = this.inferNeeds(stepOwners);
+    const needs = this[internal.inferNeeds](stepOwners);
     if (needs.length > 0) {
       result.needs = needs.map((j) => j.id);
     }
@@ -841,7 +844,10 @@ export class Job implements ExpressionSource {
       result.services = services;
     }
 
-    const { steps, outputs } = this.toStepsYaml(`Job "${this.#id}"`, "job");
+    const { steps, outputs } = this[internal.toStepsYaml](
+      `Job "${this.#id}"`,
+      "job",
+    );
     if (outputs != null) {
       result.outputs = outputs;
     }
@@ -857,11 +863,8 @@ export class Job implements ExpressionSource {
    * steps that actually survive condition filtering. `owner` and `ownerNoun`
    * name what the steps belong to in that validation's error message, so a
    * composite action built on this method reports itself rather than a job.
-   *
-   * @internal Only public so that `Action` can reuse it. Not part of the
-   * supported API.
    */
-  toStepsYaml(
+  [internal.toStepsYaml](
     owner: string,
     ownerNoun: string,
   ): { steps: unknown[]; outputs: Record<string, string> | undefined } {
@@ -875,7 +878,8 @@ export class Job implements ExpressionSource {
       const cond = effectiveConditions.get(s);
       return cond == null || !isAlwaysFalse(cond);
     };
-    const serialize = (s: Step<string>) => s.toYaml(effectiveConditions.get(s));
+    const serialize = (s: Step<string>) =>
+      s[internal.toYaml](effectiveConditions.get(s));
 
     const emittedSteps = new Set<Step<string>>();
     const steps: unknown[] = [];
@@ -924,7 +928,7 @@ function assertOutputStepsAreEmitted(
   value: ExpressionValue,
   emittedSteps: Set<Step<string>>,
 ): void {
-  for (const source of value.allSources) {
+  for (const source of value[internal.allSources]) {
     if (source instanceof Step && !emittedSteps.has(source)) {
       throw new Error(
         `${owner} output "${name}" references step "${
@@ -1031,7 +1035,7 @@ function deduplicateConditions(terms: Condition[]): Condition[] {
 
 /** Removes duplicate AND-terms within a single condition: A && B && A → A && B */
 function deduplicateAndTerms(c: Condition): Condition {
-  const children = c.flattenAnd();
+  const children = c[internal.flattenAnd]();
   if (children.length <= 1) return c;
 
   const seen = new Set<string>();
@@ -1072,7 +1076,7 @@ function complementEliminate(terms: Condition[]): Condition[] {
           terms[i] = merged;
           terms.splice(j, 1);
           // re-flatten in case the merged result is an OR
-          const flattened = terms[i].flattenOr();
+          const flattened = terms[i][internal.flattenOr]();
           if (flattened.length > 1) {
             terms.splice(i, 1, ...flattened);
           }
@@ -1094,8 +1098,8 @@ function tryComplementMerge(
   a: Condition,
   b: Condition,
 ): Condition | "tautology" | undefined {
-  const aTerms = new Set(a.getAndTerms());
-  const bTerms = new Set(b.getAndTerms());
+  const aTerms = new Set(a[internal.getAndTerms]());
+  const bTerms = new Set(b[internal.getAndTerms]());
 
   const aOnly: string[] = [];
   const common: string[] = [];
@@ -1114,7 +1118,7 @@ function tryComplementMerge(
   if (common.length === 0) return "tautology";
 
   // reconstruct from a's AND-children, excluding the complementary term
-  const aChildren = a.flattenAnd();
+  const aChildren = a[internal.flattenAnd]();
   const filtered = aChildren.filter((c) => c.toExpression() !== aOnly[0]);
   if (filtered.length === 0) return "tautology";
 
@@ -1148,7 +1152,7 @@ function areComplements(a: string, b: string): boolean {
 function applyAbsorption(terms: Condition[]): Condition[] {
   const termSets = terms.map((c) => ({
     condition: c,
-    terms: new Set(c.getAndTerms()),
+    terms: new Set(c[internal.getAndTerms]()),
   }));
 
   const absorbed = new Set<number>();
@@ -1185,7 +1189,7 @@ function extractCommonFactors(terms: Condition[]): Condition | undefined {
   if (terms.length < 2) return undefined;
 
   // get AND-term string sets for each OR term
-  const termSets = terms.map((t) => new Set(t.getAndTerms()));
+  const termSets = terms.map((t) => new Set(t[internal.getAndTerms]()));
 
   // intersect all sets to find common terms
   const common = new Set(termSets[0]);
@@ -1198,7 +1202,7 @@ function extractCommonFactors(terms: Condition[]): Condition | undefined {
   if (common.size === 0) return undefined;
 
   // get common Condition objects from the first term's children
-  const firstChildren = terms[0].flattenAnd();
+  const firstChildren = terms[0][internal.flattenAnd]();
   const commonConditions = firstChildren.filter((c) =>
     common.has(c.toExpression())
   );
@@ -1206,7 +1210,7 @@ function extractCommonFactors(terms: Condition[]): Condition | undefined {
   // build remainders for each OR term
   const remainders: Condition[] = [];
   for (const term of terms) {
-    const children = term.flattenAnd();
+    const children = term[internal.flattenAnd]();
     const filtered = children.filter((c) => !common.has(c.toExpression()));
     if (filtered.length === 0) {
       // branch is entirely common — whole expression = just common terms
@@ -1450,7 +1454,7 @@ function collectJobSources(value: unknown, out: Set<Job>): void {
   if (value instanceof Job) {
     out.add(value);
   } else if (value instanceof ExpressionValue) {
-    for (const s of value.allSources) {
+    for (const s of value[internal.allSources]) {
       if (s instanceof Job) out.add(s);
     }
   } else if (value instanceof Condition) {
@@ -1559,8 +1563,8 @@ function serializeEnvironment(
  * `${{ }}` string instead of being handed to the YAML serializer as-is.
  */
 function serializeMatrix(matrix: unknown): unknown {
-  if (matrix instanceof Matrix) return matrix.toYaml();
-  return new Matrix(matrix as Record<string, unknown>, []).toYaml();
+  if (matrix instanceof Matrix) return matrix[internal.toYaml]();
+  return new Matrix(matrix as Record<string, unknown>, [])[internal.toYaml]();
 }
 
 /**

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -1,3 +1,4 @@
+import * as internal from "./internal.ts";
 import { Condition, ExpressionValue } from "./expression.ts";
 
 type ExtractMatrixKeys<T> =
@@ -38,8 +39,7 @@ export class Matrix<_K extends string> {
     matrixDefs.set(this as Matrix<string>, def);
     for (const key of keys) {
       if (key in this) {
-        // silently overwriting would break the shadowed member — `toYaml`
-        // in particular is called when the matrix is serialized
+        // silently overwriting would break the shadowed member
         throw new Error(
           `Matrix key "${key}" conflicts with a Matrix member — rename the key.`,
         );
@@ -51,7 +51,7 @@ export class Matrix<_K extends string> {
   }
 
   /** Serializes the matrix definition to its YAML form. */
-  toYaml(): Record<string, unknown> {
+  [internal.toYaml](): Record<string, unknown> {
     return serializeValue(matrixDefOf(this as Matrix<string>)) as Record<
       string,
       unknown
@@ -64,8 +64,8 @@ export class Matrix<_K extends string> {
  * ExpressionValue entries left intact.
  *
  * Needed to infer job `needs` from expressions embedded in a matrix — the
- * definition is otherwise only reachable through `toYaml`, which has already
- * flattened those entries to strings.
+ * definition is otherwise only reachable through its serialized form, which
+ * has already flattened those entries to strings.
  */
 export function matrixDefOf(matrix: Matrix<string>): Record<string, unknown> {
   return matrixDefs.get(matrix) ?? {};

--- a/src/step.ts
+++ b/src/step.ts
@@ -1,3 +1,4 @@
+import * as internal from "./internal.ts";
 import {
   Condition,
   type ExpressionSource,
@@ -190,7 +191,7 @@ export class Step<O extends string = never> implements ExpressionSource {
    * Serializes this step to its YAML object form. `effectiveIf` overrides
    * `config.if` with the condition resolved by the job's dependency graph.
    */
-  toYaml(effectiveIf?: Condition): Record<string, unknown> {
+  [internal.toYaml](effectiveIf?: Condition): Record<string, unknown> {
     const result: Record<string, unknown> = {};
 
     if (this.config.name != null) {

--- a/src/step_test.ts
+++ b/src/step_test.ts
@@ -1,3 +1,4 @@
+import * as internal from "./internal.ts";
 import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import {
   artifact,
@@ -853,9 +854,9 @@ jobs:
 Deno.test("a matrix key that would shadow a Matrix member throws", () => {
   setup();
   assertThrows(
-    () => defineMatrix({ toYaml: ["a", "b"] } as Record<string, unknown>),
+    () => defineMatrix({ constructor: ["a", "b"] } as Record<string, unknown>),
     Error,
-    'Matrix key "toYaml" conflicts with a Matrix member',
+    'Matrix key "constructor" conflicts with a Matrix member',
   );
 });
 
@@ -870,12 +871,14 @@ Deno.test("matrixDefOf exposes the unserialized definition and its sources", () 
 
   // toYaml has already flattened the expression to a string, so needs
   // inference has to read the definition through matrixDefOf instead
-  assertEquals(matrix.toYaml(), {
+  assertEquals(matrix[internal.toYaml](), {
     version: "${{ fromJSON(steps.produce.outputs.versions) }}",
   });
   const def = matrixDefOf(matrix);
   assertEquals(Object.keys(def), ["version"]);
-  assertEquals([...(def.version as ExpressionValue).allSources], [produce]);
+  assertEquals([...(def.version as ExpressionValue)[internal.allSources]], [
+    produce,
+  ]);
 });
 
 Deno.test("a matrix built from a job output infers needs on that job", () => {
@@ -934,17 +937,17 @@ jobs:
 Deno.test("Step.toYaml omits generated ids and honours an effective condition", () => {
   setup();
   const generated = step({ name: "Generated", run: "g" });
-  assertEquals(generated.toYaml(), { name: "Generated", run: "g" });
+  assertEquals(generated[internal.toYaml](), { name: "Generated", run: "g" });
 
   const explicit = step({ id: "explicit", name: "Explicit", run: "e" });
-  assertEquals(explicit.toYaml(), {
+  assertEquals(explicit[internal.toYaml](), {
     name: "Explicit",
     id: "explicit",
     run: "e",
   });
 
   const conditional = step({ name: "C", run: "c", if: isBranch("main") });
-  assertEquals(conditional.toYaml(isTag()), {
+  assertEquals(conditional[internal.toYaml](isTag()), {
     name: "C",
     if: "startsWith(github.ref, 'refs/tags/')",
     run: "c",

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,3 +1,4 @@
+import * as internal from "./internal.ts";
 import { stringify } from "@std/yaml/stringify";
 import {
   Job,
@@ -153,7 +154,7 @@ export class Workflow {
     // pre-resolve all jobs and build step→job mapping for cross-job deps
     const stepOwners = new Map<Step<string>, Job[]>();
     for (const job of this.#jobs.values()) {
-      for (const s of job.resolveSteps()) {
+      for (const s of job[internal.resolveSteps]()) {
         let owners = stepOwners.get(s);
         if (!owners) {
           owners = [];
@@ -167,7 +168,7 @@ export class Workflow {
     const jobs: Record<string, unknown> = {};
     for (const [id, job] of this.#jobs) {
       this.#assertNeedsAreInWorkflow(id, job, stepOwners);
-      jobs[id] = job.toYaml(stepOwners);
+      jobs[id] = job[internal.toYaml](stepOwners);
     }
     obj.jobs = jobs;
 
@@ -208,7 +209,7 @@ export class Workflow {
     job: Job,
     stepOwners: Map<Step<string>, Job[]>,
   ): void {
-    for (const dep of job.inferNeeds(stepOwners)) {
+    for (const dep of job[internal.inferNeeds](stepOwners)) {
       if (!this.#jobs.has(dep.id)) {
         throw new Error(
           `Job "${id}" depends on job "${dep.id}", which is not part of this workflow.`,


### PR DESCRIPTION
Members shared between the package's modules but not meant for users are now keyed by `unique symbol`s declared in `src/internal.ts`, which `mod.ts` does not export. Consumers have no way to spell the keys, so the members are unreachable outside the package, while inside it they read as `job[internal.toYaml]()`.

## Converted members

- `Step`: `toYaml`
- `Job`: `toYaml`, `toStepsYaml`, `resolveSteps`, `inferNeeds`
- `Matrix`, `ActionInputs`: `toYaml`
- `ExpressionValue`: `source`, `allSources` (and `ConcatValue.concatParts`)
- `Condition` and subclasses: `getAndTerms`, `flattenAnd`, `flattenOr`, `withSources`

`isAlwaysTrue`, `isAlwaysFalse`, `isPossiblyTrue` and `toExpression` stay public on `Condition`, as do the descriptive fields on `Step` and `StepRef`.

## Follow-on cleanups

- `sourcesFrom` now takes `ExpressionValue | Condition` only; the structural `{ source?: ... }` shape was only used by tests.
- The `Matrix` and `ActionInputs` shadow-check tests used `toYaml` as the colliding key; they now use `constructor`. `toYaml` is now a legal matrix key and action input name.
- The `@internal` note on `Job.toStepsYaml` is removed since the restriction is now enforced.

## Breaking change

Calls to `job.toYaml()`, `step.toYaml()`, `matrix.toYaml()`, `expr.allSources`, `expr.source` or the `Condition` flattening helpers from outside the package no longer type check. Use `toYamlString()` on `Workflow` or `Action` instead. Suggest a major version bump when tagging.
