### PR TITLE
chore: clean up stale comments, dead code and layout after recent refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,12 @@ workflow({
 });
 ```
 
-Generate via the `gagen` cli:
+Generate via the `gagen` cli, or run the script directly:
 
 ```sh
-# or alternatively run the script directly
 npx gagen
+# or
+deno run -A .github/workflows/ci.ts
 ```
 
 This generates a `ci.generated.yml` with steps in the correct order and figures

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ workflow({
 });
 ```
 
-Generate via the `gagen` cli, or run the script directly:
+Generate via the `gagen` cli:
 
 ```sh
 npx gagen
-# or
+# or alternatively run the script directly
 deno run -A .github/workflows/ci.ts
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,7 @@ export async function runCli() {
 function pullVersions(workflowsDir: string) {
   const entries = fs.readdirSync(workflowsDir);
 
-  const yamlContents = findGeneratedYamlFiles(workflowsDir).map((f) =>
+  const yamlContents = findGeneratedYamlFiles(workflowsDir, entries).map((f) =>
     fs.readFileSync(f, "utf8")
   );
   const { versions, conflicts } = collectActionVersions(yamlContents);
@@ -113,8 +113,11 @@ function pullVersions(workflowsDir: string) {
  * the workflows directory plus a composite action's `action.yml` at the repo
  * root, since dependabot bumps the pins in both.
  */
-function findGeneratedYamlFiles(workflowsDir: string): string[] {
-  const files = fs.readdirSync(workflowsDir)
+function findGeneratedYamlFiles(
+  workflowsDir: string,
+  entries: readonly string[],
+): string[] {
+  const files = entries
     .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
     .map((f) => resolve(workflowsDir, f));
   const repoRoot = dirname(dirname(workflowsDir));
@@ -137,7 +140,7 @@ function findWorkflowsDir(): string | undefined {
 }
 
 function helpText(): string {
-  return `gagen — generate GitHub Actions workflows from TypeScript
+  return `gagen — generate GitHub Actions workflows and composite actions from TypeScript
 
 Usage:
   gagen [options]

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -1,7 +1,5 @@
 import * as internal from "./internal.ts";
 
-// types that step/job/workflow will reference back to
-
 /** Something an expression can depend on, such as a step or a job. */
 export type ExpressionSource = { readonly id: string };
 
@@ -16,7 +14,6 @@ export type TernaryValue = string | number | boolean | ExpressionValue;
  */
 export class ExpressionValue {
   readonly #expression: string;
-  readonly [internal.source]: ExpressionSource | undefined;
   readonly #allSources: ReadonlySet<ExpressionSource>;
 
   constructor(
@@ -25,12 +22,11 @@ export class ExpressionValue {
   ) {
     this.#expression = expression;
     if (source instanceof Set) {
-      this[internal.source] = undefined;
       this.#allSources = source as ReadonlySet<ExpressionSource>;
     } else {
-      const s = source as ExpressionSource | undefined;
-      this[internal.source] = s;
-      this.#allSources = s ? new Set([s]) : EMPTY_SOURCES;
+      this.#allSources = source
+        ? new Set([source as ExpressionSource])
+        : EMPTY_SOURCES;
     }
   }
 
@@ -229,17 +225,28 @@ export abstract class Condition {
     return [this];
   }
 
-  /** returns true if this condition always evaluates to true */
+  /**
+   * Gets if this condition is statically known to be true, such as
+   * `conditions.isTrue()` or a comparison of two equal literals. Steps and
+   * jobs with such a condition serialize without an `if`.
+   */
   isAlwaysTrue(): boolean {
     return false;
   }
 
-  /** returns true if this condition always evaluates to false */
+  /**
+   * Gets if this condition is statically known to be false. Steps with such a
+   * condition are dropped from the generated job entirely.
+   */
   isAlwaysFalse(): boolean {
     return false;
   }
 
-  /** returns true if this condition could possibly evaluate to true */
+  /**
+   * Gets if this condition could evaluate to true at runtime, meaning it is
+   * not statically known to be false. Handy for deciding in a script whether a
+   * conditional step will be emitted at all.
+   */
   isPossiblyTrue(): boolean {
     return !this.isAlwaysFalse();
   }
@@ -655,10 +662,10 @@ export function formatLiteral(value: string | number | boolean): string {
 
 /** Collects the sources of any number of expression values or conditions. */
 export function sourcesFrom(
-  ...sourceables: (ExpressionValue | Condition)[]
+  ...values: (ExpressionValue | Condition)[]
 ): ReadonlySet<ExpressionSource> {
   const set = new Set<ExpressionSource>();
-  for (const v of sourceables) {
+  for (const v of values) {
     if (v instanceof Condition) {
       for (const s of v.sources) set.add(s);
     } else {
@@ -815,72 +822,6 @@ function deduplicatedLogical(
 
 // --- ternary expression builders ---
 
-interface TernaryBranch {
-  condition: Condition;
-  value: TernaryValue;
-}
-
-function collectTernarySources(
-  branches: TernaryBranch[],
-): Set<ExpressionSource> {
-  const set = new Set<ExpressionSource>();
-  for (const { condition, value } of branches) {
-    for (const s of condition.sources) set.add(s);
-    if (value instanceof ExpressionValue) {
-      for (const s of value[internal.allSources]) set.add(s);
-    }
-  }
-  return set;
-}
-
-/**
- * A ternary renders as `cond && value || fallback`, which only works when the
- * value is truthy: GitHub's `&&` yields its falsy operand, so a falsy value
- * makes the whole expression fall through to the fallback no matter what the
- * condition says. Dynamic values can't be checked, but literals can.
- */
-function assertTruthyTernaryValue(value: TernaryValue): void {
-  if (!isStaticallyFalsy(value)) return;
-  throw new Error(
-    `A ternary value must not be falsy, but got ${
-      formatTernaryValue(value)
-    }. ` +
-      "GitHub evaluates `condition && value || fallback`, so a falsy value " +
-      "always falls through to the fallback.",
-  );
-}
-
-function isStaticallyFalsy(value: TernaryValue): boolean {
-  if (value instanceof ExpressionValue) {
-    const expression = value.expression;
-    if (literalTypeOf(expression) === "string") {
-      return unquoteStringLiteral(expression) === "";
-    }
-    return expression === "false" || expression === "0";
-  }
-  return value === false || value === 0 || value === "";
-}
-
-// whether a condition needs parentheses when used as `cond && value`
-function needsParensForTernary(condition: Condition): boolean {
-  if (condition instanceof LogicalCondition && condition.op === "||") {
-    return true;
-  }
-  if (condition instanceof RawCondition) {
-    return condition.toExpression().includes("||");
-  }
-  return false;
-}
-
-function formatTernaryValue(value: TernaryValue): string {
-  if (!(value instanceof ExpressionValue)) return formatLiteral(value);
-  // a value that is itself a ternary (or any other logical expression) has to
-  // be parenthesized so it doesn't merge into the surrounding `&&`/`||` chain
-  return containsLogicalOperator(value.expression)
-    ? `(${value.expression})`
-    : value.expression;
-}
-
 /**
  * Intermediate builder after `.then(value)`. Call `.else()` to produce the
  * final `ExpressionValue`, or `.elseIf()` to add another branch.
@@ -963,6 +904,72 @@ export class ElseIfBuilder {
       this.#sources,
     );
   }
+}
+
+interface TernaryBranch {
+  condition: Condition;
+  value: TernaryValue;
+}
+
+function collectTernarySources(
+  branches: TernaryBranch[],
+): Set<ExpressionSource> {
+  const set = new Set<ExpressionSource>();
+  for (const { condition, value } of branches) {
+    for (const s of condition.sources) set.add(s);
+    if (value instanceof ExpressionValue) {
+      for (const s of value[internal.allSources]) set.add(s);
+    }
+  }
+  return set;
+}
+
+/**
+ * A ternary renders as `cond && value || fallback`, which only works when the
+ * value is truthy: GitHub's `&&` yields its falsy operand, so a falsy value
+ * makes the whole expression fall through to the fallback no matter what the
+ * condition says. Dynamic values can't be checked, but literals can.
+ */
+function assertTruthyTernaryValue(value: TernaryValue): void {
+  if (!isStaticallyFalsy(value)) return;
+  throw new Error(
+    `A ternary value must not be falsy, but got ${
+      formatTernaryValue(value)
+    }. ` +
+      "GitHub evaluates `condition && value || fallback`, so a falsy value " +
+      "always falls through to the fallback.",
+  );
+}
+
+function isStaticallyFalsy(value: TernaryValue): boolean {
+  if (value instanceof ExpressionValue) {
+    const expression = value.expression;
+    if (literalTypeOf(expression) === "string") {
+      return unquoteStringLiteral(expression) === "";
+    }
+    return expression === "false" || expression === "0";
+  }
+  return value === false || value === 0 || value === "";
+}
+
+// whether a condition needs parentheses when used as `cond && value`
+function needsParensForTernary(condition: Condition): boolean {
+  if (condition instanceof LogicalCondition && condition.op === "||") {
+    return true;
+  }
+  if (condition instanceof RawCondition) {
+    return condition.toExpression().includes("||");
+  }
+  return false;
+}
+
+function formatTernaryValue(value: TernaryValue): string {
+  if (!(value instanceof ExpressionValue)) return formatLiteral(value);
+  // a value that is itself a ternary (or any other logical expression) has to
+  // be parenthesized so it doesn't merge into the surrounding `&&`/`||` chain
+  return containsLogicalOperator(value.expression)
+    ? `(${value.expression})`
+    : value.expression;
 }
 
 // --- string concatenation ---

--- a/src/expression_test.ts
+++ b/src/expression_test.ts
@@ -135,14 +135,13 @@ Deno.test("ExpressionValue chaining or().and() from values", () => {
 
 Deno.test("ExpressionValue no source by default", () => {
   const v = new ExpressionValue("github.ref");
-  assertEquals(v[internal.source], undefined);
   assertEquals(v.equals("main").sources.size, 0);
 });
 
 Deno.test("ExpressionValue source flows into equals", () => {
   const src = { id: "step_1" };
   const v = new ExpressionValue("steps.check.outputs.result", src);
-  assertEquals(v[internal.source], src);
+  assertEquals([...v[internal.allSources]], [src]);
   const c = v.equals("success");
   assertEquals(c.sources.size, 1);
   assertEquals(c.sources.has(src), true);
@@ -1544,11 +1543,10 @@ Deno.test("sourcesFrom deduplicates and tolerates missing sources", () => {
   assertEquals(set.size, 1);
 });
 
-Deno.test("ExpressionValue built from a source set has no single source", () => {
+Deno.test("ExpressionValue built from a source set tracks every source", () => {
   const s1 = { id: "s1" };
   const s2 = { id: "s2" };
   const v = new ExpressionValue("a", new Set([s1, s2]));
-  assertEquals(v[internal.source], undefined);
   assertEquals(v[internal.allSources].size, 2);
   assertEquals(v.equals("x").sources.size, 2);
 });

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -21,9 +21,6 @@ export const resolveSteps: unique symbol = Symbol("gagen.resolveSteps");
 /** Infers the jobs a job depends on. */
 export const inferNeeds: unique symbol = Symbol("gagen.inferNeeds");
 
-/** The single source an expression value was created from, if any. */
-export const source: unique symbol = Symbol("gagen.source");
-
 /** Every source an expression value references. */
 export const allSources: unique symbol = Symbol("gagen.allSources");
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -160,7 +160,7 @@ function combineContexts(entry: GraphEntry): Condition | undefined {
     return toCondition(entry.contexts[0]);
   }
   const conditions = entry.contexts.map((c) => toCondition(c));
-  return simplifyOrConditions(conditions) ?? undefined;
+  return simplifyOrConditions(conditions);
 }
 
 /** ANDs two optional conditions together (for nesting StepRef conditions). */
@@ -232,7 +232,7 @@ function propagatableRunCondition(item: StepLike): ConditionLike | undefined {
     if (condition == null) return undefined;
     childConditions.push(toCondition(condition));
   }
-  return simplifyOrConditions(childConditions) ?? undefined;
+  return simplifyOrConditions(childConditions);
 }
 
 interface DeferredAfterDep {
@@ -591,6 +591,11 @@ export class Job implements ExpressionSource {
     return { graph, leafSteps, membership };
   }
 
+  /**
+   * Resolves every step the job runs, in execution order, with parallel group
+   * members flattened into the list. `#resolveUnits` is the grouped form used
+   * for serialization.
+   */
   [internal.resolveSteps](): Step<string>[] {
     const { graph, leafSteps } = this.#buildGraph();
     const priority = computePriorities(graph, leafSteps);
@@ -939,6 +944,19 @@ function assertOutputStepsAreEmitted(
   }
 }
 
+/** Creates a job with the given id. */
+export function job(id: string, config: JobDef): Job {
+  if ("uses" in config) {
+    const { id: _id, ...reusableConfig } = config;
+    return new Job(id, reusableConfig);
+  }
+  const { id: _id, steps, outputs, ...jobConfig } = config;
+  return new Job(id, jobConfig, {
+    steps: Array.isArray(steps) ? steps : [steps],
+    outputs,
+  });
+}
+
 // --- effective conditions ---
 
 /**
@@ -975,8 +993,9 @@ function computeEffectiveConditions(
  * 1. Deduplicates identical conditions (by expression string)
  * 2. Deduplicates AND-terms within each condition (A && B && A → A && B)
  * 3. Complement elimination: A && X || A && !X → A (with inline OR-flattening)
- * 4. Absorption: A || (A && B) → A
- * 5. Common factor extraction: (A && B) || (A && C) → A && (B || C)
+ * 4. Deduplicates again, since complement merges can produce duplicates
+ * 5. Absorption: A || (A && B) → A
+ * 6. Common factor extraction: (A && B) || (A && C) → A && (B || C)
  *
  * Note: OR-flattening is done inline during complement elimination (not upfront)
  * so that absorption can still match compound conditions against their parents.
@@ -1372,6 +1391,7 @@ function topoSort(
   return result;
 }
 
+/** Names a step in error messages by whatever the user gave it. */
 function stepLabel(s: Step<string>): string {
   return s.config.name ?? s.config.uses ?? s.id;
 }
@@ -1636,19 +1656,4 @@ function assertValidJobId(id: string): void {
       `Invalid job id ${JSON.stringify(id)}. ${JOB_ID_REQUIREMENT}`,
     );
   }
-}
-
-// --- job() free function ---
-
-/** Creates a job with the given id. */
-export function job(id: string, config: JobDef): Job {
-  if ("uses" in config) {
-    const { id: _id, ...reusableConfig } = config;
-    return new Job(id, reusableConfig);
-  }
-  const { id: _id, steps, outputs, ...jobConfig } = config;
-  return new Job(id, jobConfig, {
-    steps: Array.isArray(steps) ? steps : [steps],
-    outputs,
-  });
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -20,8 +20,8 @@ export type {
   StepsJobConfig,
   StepsJobDef,
 } from "./job.ts";
-export { isLinting, Workflow, workflow } from "./workflow.ts";
-export type { WriteOrLintOptions } from "./write.ts";
+export { Workflow, workflow } from "./workflow.ts";
+export { isLinting, isUpdatingPins, type WriteOrLintOptions } from "./write.ts";
 export { Action, action, ActionInputs, defineInputs } from "./action.ts";
 export type {
   ActionConfig,

--- a/src/step.ts
+++ b/src/step.ts
@@ -535,7 +535,7 @@ export class StepRef<O extends string = never> {
   }
 }
 
-// --- serialization helpers ---
+// --- validation and serialization helpers ---
 
 /**
  * Validates that a step does not combine mutually exclusive control keys.
@@ -623,7 +623,7 @@ export function normalizeStepLike(
   return stepFromConfig(item);
 }
 
-/** Extracts the underlying Step from a StepLike (Step or StepRef). */
+/** Extracts the underlying Step from a StepLike (Step, StepRef, or plain config). */
 export function unwrapStep(item: StepLike): Step<string> {
   const normalized = normalizeStepLike(item);
   return normalized instanceof StepRef ? normalized.step : normalized;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -13,13 +13,6 @@ import { type ConfigValue, serializeConfigValues, type Step } from "./step.ts";
 import { type WriteOrLintOptions, writeOrLintYaml } from "./write.ts";
 import fs from "node:fs";
 
-export {
-  assertKnownFlags,
-  isLinting,
-  isUpdatingPins,
-  KNOWN_FLAGS,
-} from "./write.ts";
-
 /** An input declared by a `workflow_call` trigger. */
 export interface WorkflowCallInput {
   type: "string" | "boolean" | "number";

--- a/src/write.ts
+++ b/src/write.ts
@@ -57,7 +57,7 @@ export function writeOrLintYaml(
       // reuse previously resolved hashes from existing file to avoid
       // redundant git ls-remote calls on subsequent runs
       let cache: PinEntry[] | undefined;
-      if (!isUpdatingPins()) {
+      if (!isUpdatingPinsNow()) {
         try {
           const existing = fs.readFileSync(options.filePath, {
             encoding: "utf8",
@@ -74,7 +74,11 @@ export function writeOrLintYaml(
   }
 }
 
-/** Gets if linting would occur when using `writeOrLint`. */
+/**
+ * Gets if `writeOrLint` will lint the generated files instead of writing them
+ * (`--lint`). Useful for skipping work in a script that only makes sense when
+ * generating.
+ */
 export const isLinting: boolean = isLintingNow();
 
 /**
@@ -88,8 +92,14 @@ function isLintingNow(): boolean {
   return process.argv.includes("--lint");
 }
 
-/** Gets if pins should be re-resolved when using `writeOrLint`. */
-export function isUpdatingPins(): boolean {
+/**
+ * Gets if `writeOrLint` will re-resolve every pinned action instead of reusing
+ * the hashes in the existing file (`--update-pins`).
+ */
+export const isUpdatingPins: boolean = isUpdatingPinsNow();
+
+/** Gets if pins should be re-resolved, reading the flags on each call. */
+function isUpdatingPinsNow(): boolean {
   return process.argv.includes("--update-pins");
 }
 


### PR DESCRIPTION
Follow-up review pass after the composite actions and internal-symbol changes.

## Stale or wrong

- `simplifyOrConditions` doc listed five steps while the body has six; added the missing re-dedup step and renumbered.
- `ExpressionValue[internal.source]` was write-only after `sourcesFrom` was narrowed. Removed the field, the `source` symbol and the test assertions on it.
- `workflow.ts` still re-exported the flag helpers from `write.ts` with no remaining consumer. Removed; `mod.ts` now exports from `write.ts` directly.
- `sourcesFrom` still named its parameter `sourceables` after the structural shape was dropped. Renamed to `values`.
- Misleading "types that step/job/workflow will reference back to" header comment in `expression.ts` removed.
- README quick start had the "or run the script directly" comment above `npx gagen` as if it introduced that command.
- CLI tagline now mentions composite actions.

## Dead or redundant

- No-op `?? undefined` on two `simplifyOrConditions` calls.
- `--pull-versions` read the workflows directory twice; the helper now takes the already-read entries.

## Docs added

- `Job[internal.resolveSteps]` (the only undocumented member), `stepLabel`, `unwrapStep`.
- `Condition.isAlwaysTrue`, `isAlwaysFalse`, `isPossiblyTrue` now explain what "statically known" means and the effect on generated output.

## API

- `isUpdatingPins` is now exported from `mod.ts` as a boolean, mirroring `isLinting`. It was previously a function that was not exported.

## Layout

- `job()` moved from the bottom of `job.ts` to right after the `Job` class, matching `workflow.ts` and `action.ts`.
- `ThenBuilder` and `ElseIfBuilder` moved above their private helpers.
- `step.ts` section header "serialization helpers" renamed to "validation and serialization helpers" since it opens with a validator.
