### PR TITLE
feat: allow comparing an expression against another expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ ref.startsWith("refs/tags/").not();
 os.equals("linux").and(ref.startsWith("refs/tags/"));
 // => matrix.os == 'linux' && startsWith(github.ref, 'refs/tags/')
 
+// compare against another expression, ex. two step outputs
+after.outputs.hash.notEquals(before.outputs.hash);
+// => steps.after.outputs.hash != steps.before.outputs.hash
+
 // use on steps
 const deploy = step.dependsOn(build).if(
   ref.equals("refs/heads/main").and(os.equals("linux")),

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -8,6 +8,9 @@ const EMPTY_SOURCES: ReadonlySet<ExpressionSource> = new Set();
 /** Values that can appear in ternary `.then()` / `.else()` branches. */
 export type TernaryValue = string | number | boolean | ExpressionValue;
 
+/** Values that can be compared against: a literal or another expression. */
+export type Operand = string | number | boolean | ExpressionValue;
+
 /**
  * An expression that resolves to a value inside a GitHub Actions workflow.
  * Supports fluent comparison methods that produce Conditions.
@@ -41,8 +44,8 @@ export class ExpressionValue {
   }
 
   /** `this == value`, simplified when this value is a known literal */
-  equals(value: string | number | boolean): Condition {
-    const sources = sourcesFrom(this);
+  equals(value: Operand): Condition {
+    const sources = operandSources(this, value);
     const isEqual = literalEquality(this.#expression, value);
     if (isEqual != null) {
       return new RawCondition(isEqual ? "true" : "false", sources);
@@ -51,8 +54,8 @@ export class ExpressionValue {
   }
 
   /** `this != value`, simplified when this value is a known literal */
-  notEquals(value: string | number | boolean): Condition {
-    const sources = sourcesFrom(this);
+  notEquals(value: Operand): Condition {
+    const sources = operandSources(this, value);
     const isEqual = literalEquality(this.#expression, value);
     if (isEqual != null) {
       return new RawCondition(isEqual ? "false" : "true", sources);
@@ -61,29 +64,29 @@ export class ExpressionValue {
   }
 
   /** `startsWith(this, prefix)` */
-  startsWith(prefix: string): Condition {
+  startsWith(prefix: string | ExpressionValue): Condition {
     return new FunctionCallCondition(
       "startsWith",
-      [this.#expression, formatLiteral(prefix)],
-      sourcesFrom(this),
+      [this.#expression, formatOperand(prefix)],
+      operandSources(this, prefix),
     );
   }
 
   /** `endsWith(this, suffix)` */
-  endsWith(suffix: string): Condition {
+  endsWith(suffix: string | ExpressionValue): Condition {
     return new FunctionCallCondition(
       "endsWith",
-      [this.#expression, formatLiteral(suffix)],
-      sourcesFrom(this),
+      [this.#expression, formatOperand(suffix)],
+      operandSources(this, suffix),
     );
   }
 
   /** `contains(this, substring)` */
-  contains(substring: string): Condition {
+  contains(substring: string | ExpressionValue): Condition {
     return new FunctionCallCondition(
       "contains",
-      [this.#expression, formatLiteral(substring)],
-      sourcesFrom(this),
+      [this.#expression, formatOperand(substring)],
+      operandSources(this, substring),
     );
   }
 
@@ -98,42 +101,42 @@ export class ExpressionValue {
   }
 
   /** `this > value` */
-  greaterThan(value: number): Condition {
+  greaterThan(value: number | ExpressionValue): Condition {
     return new ComparisonCondition(
       this.#expression,
       ">",
       value,
-      sourcesFrom(this),
+      operandSources(this, value),
     );
   }
 
   /** `this >= value` */
-  greaterThanOrEqual(value: number): Condition {
+  greaterThanOrEqual(value: number | ExpressionValue): Condition {
     return new ComparisonCondition(
       this.#expression,
       ">=",
       value,
-      sourcesFrom(this),
+      operandSources(this, value),
     );
   }
 
   /** `this < value` */
-  lessThan(value: number): Condition {
+  lessThan(value: number | ExpressionValue): Condition {
     return new ComparisonCondition(
       this.#expression,
       "<",
       value,
-      sourcesFrom(this),
+      operandSources(this, value),
     );
   }
 
   /** `this <= value` */
-  lessThanOrEqual(value: number): Condition {
+  lessThanOrEqual(value: number | ExpressionValue): Condition {
     return new ComparisonCondition(
       this.#expression,
       "<=",
       value,
-      sourcesFrom(this),
+      operandSources(this, value),
     );
   }
 
@@ -287,25 +290,26 @@ const NEGATED_OP: Record<ComparisonOp, ComparisonOp> = {
 export class ComparisonCondition extends Condition {
   readonly #left: string;
   readonly #op: ComparisonOp;
-  readonly #right: string | number | boolean;
+  /** The rendered right side: a formatted literal or a raw expression. */
+  readonly #right: string;
 
   constructor(
     left: string,
     op: ComparisonOp,
-    right: string | number | boolean,
+    right: Operand,
     sources: ReadonlySet<ExpressionSource>,
   ) {
     super(sources);
     this.#left = left;
     this.#op = op;
-    this.#right = right;
+    this.#right = formatOperand(right);
   }
 
   override not(): Condition {
     return new ComparisonCondition(
       this.#left,
       NEGATED_OP[this.#op],
-      this.#right,
+      new ExpressionValue(this.#right),
       this.sources,
     );
   }
@@ -316,7 +320,7 @@ export class ComparisonCondition extends Condition {
     return new ComparisonCondition(
       this.#left,
       this.#op,
-      this.#right,
+      new ExpressionValue(this.#right),
       mergeSources(this.sources, sources),
     );
   }
@@ -327,7 +331,7 @@ export class ComparisonCondition extends Condition {
     const left = containsLogicalOperator(this.#left)
       ? `(${this.#left})`
       : this.#left;
-    return `${left} ${this.#op} ${formatLiteral(this.#right)}`;
+    return `${left} ${this.#op} ${this.#right}`;
   }
 }
 
@@ -660,6 +664,27 @@ export function formatLiteral(value: string | number | boolean): string {
   return String(value);
 }
 
+/**
+ * Renders a comparison or function argument: a literal is quoted, while an
+ * expression is inserted as-is, parenthesized when it's a ternary or other
+ * logical expression since those bind less tightly than a comparison.
+ */
+function formatOperand(value: Operand): string {
+  if (!(value instanceof ExpressionValue)) return formatLiteral(value);
+  const expression = value.expression;
+  return containsLogicalOperator(expression) ? `(${expression})` : expression;
+}
+
+/** The sources of an expression and, when it's an expression, its operand. */
+function operandSources(
+  left: ExpressionValue,
+  right: Operand,
+): ReadonlySet<ExpressionSource> {
+  return right instanceof ExpressionValue
+    ? sourcesFrom(left, right)
+    : sourcesFrom(left);
+}
+
 /** Collects the sources of any number of expression values or conditions. */
 export function sourcesFrom(
   ...values: (ExpressionValue | Condition)[]
@@ -697,8 +722,9 @@ function escapeSingleQuotes(value: string): string {
  */
 function literalEquality(
   expression: string,
-  value: string | number | boolean,
+  value: Operand,
 ): boolean | undefined {
+  if (value instanceof ExpressionValue) return undefined;
   const valueType = typeof value;
   if (literalTypeOf(expression) !== valueType) return undefined;
   if (typeof value === "string") {

--- a/src/expression_test.ts
+++ b/src/expression_test.ts
@@ -153,6 +153,81 @@ Deno.test("ExpressionValue source flows into notEquals", () => {
   assertEquals(v.notEquals("fail").sources.has(src), true);
 });
 
+Deno.test("ExpressionValue equals another expression", () => {
+  const before = new ExpressionValue("steps.before.outputs.hash");
+  const after = new ExpressionValue("steps.after.outputs.hash");
+  assertEquals(
+    after.equals(before).toExpression(),
+    "steps.after.outputs.hash == steps.before.outputs.hash",
+  );
+  assertEquals(
+    after.notEquals(before).toExpression(),
+    "steps.after.outputs.hash != steps.before.outputs.hash",
+  );
+  assertEquals(
+    after.notEquals(before).not().toExpression(),
+    "steps.after.outputs.hash == steps.before.outputs.hash",
+  );
+});
+
+Deno.test("ExpressionValue compared to a ternary parenthesizes it", () => {
+  const os = new ExpressionValue("matrix.os");
+  const runner = os.equals("linux").then("ubuntu").else("macos");
+  assertEquals(
+    new ExpressionValue("inputs.runner").equals(runner).toExpression(),
+    "inputs.runner == (matrix.os == 'linux' && 'ubuntu' || 'macos')",
+  );
+});
+
+Deno.test("ExpressionValue sources flow from both sides of a comparison", () => {
+  const leftSrc = { id: "step_after" };
+  const rightSrc = { id: "step_before" };
+  const after = new ExpressionValue("steps.after.outputs.hash", leftSrc);
+  const before = new ExpressionValue("steps.before.outputs.hash", rightSrc);
+  const c = after.notEquals(before);
+  assertEquals(c.sources.has(leftSrc), true);
+  assertEquals(c.sources.has(rightSrc), true);
+  // and survive negation and source merging
+  assertEquals(c.not().sources.has(rightSrc), true);
+});
+
+Deno.test("ExpressionValue number comparisons accept an expression", () => {
+  const count = new ExpressionValue("steps.count.outputs.value");
+  const limit = new ExpressionValue("inputs.limit");
+  assertEquals(
+    count.greaterThan(limit).toExpression(),
+    "steps.count.outputs.value > inputs.limit",
+  );
+  assertEquals(
+    count.lessThanOrEqual(limit).toExpression(),
+    "steps.count.outputs.value <= inputs.limit",
+  );
+});
+
+Deno.test("ExpressionValue string functions accept an expression", () => {
+  const src = { id: "step_1" };
+  const ref = new ExpressionValue("github.ref");
+  const prefix = new ExpressionValue("steps.prefix.outputs.value", src);
+  const c = ref.startsWith(prefix);
+  assertEquals(
+    c.toExpression(),
+    "startsWith(github.ref, steps.prefix.outputs.value)",
+  );
+  assertEquals(c.sources.has(src), true);
+  assertEquals(
+    ref.contains(prefix).toExpression(),
+    "contains(github.ref, steps.prefix.outputs.value)",
+  );
+});
+
+Deno.test("literal equals an expression does not simplify", () => {
+  const value = new ExpressionValue("'linux'");
+  assertEquals(
+    value.equals(new ExpressionValue("matrix.os")).toExpression(),
+    "'linux' == matrix.os",
+  );
+});
+
 Deno.test("ExpressionValue source flows into startsWith", () => {
   const src = { id: "step_1" };
   const v = new ExpressionValue("steps.check.outputs.ref", src);

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -57,6 +57,7 @@ export type {
   ExpressionSource,
   ExprMap,
   ExprOf,
+  Operand,
   TernaryValue,
 } from "./expression.ts";
 // Only `RefResolver` belongs to the public API — it appears in the `pinDeps`


### PR DESCRIPTION
`equals`, `notEquals`, `greaterThan`, `greaterThanOrEqual`, `lessThan`, `lessThanOrEqual`, `startsWith`, `endsWith` and `contains` now accept an `ExpressionValue` operand in addition to a literal:

```ts
const saveCache = step({
  if: after.outputs.hash.notEquals(before.outputs.hash),
  // => steps.after.outputs.hash != steps.before.outputs.hash
});
```

- The operand's sources flow into the condition, so a step referenced on the right side is pulled in as a dependency like one on the left.
- A ternary or other logical expression on the right side is parenthesized, since comparisons bind tighter than `&&` and `||`.
- Literal simplification is skipped when the operand is an expression.
- `ComparisonCondition` now stores the rendered right side; `not()` and source merging route it back through as a raw expression so it isn't re-quoted.

Motivation: writing this in dprint/check#25 was a type error, but `deno run` doesn't type check, so the expression was stringified into a nested `${{ }}` inside the `if`, which GitHub rejects.
